### PR TITLE
refactor: remove the dependency to ControlContainer

### DIFF
--- a/libs/forms/core/src/control.types.ts
+++ b/libs/forms/core/src/control.types.ts
@@ -1,5 +1,3 @@
-import { AbstractControl, ControlContainer, FormGroup } from '@angular/forms';
-
 export type DynControlType = string; // Control ID
 
 // Form Control Type
@@ -8,10 +6,4 @@ export enum DynInstanceType {
   Array = 'ARRAY',
   Control = 'CONTROL',
   Container = 'CONTAINER',
-}
-
-// typed ControlContainer
-export interface DynControlParent<T extends AbstractControl = FormGroup>
-extends ControlContainer {
-  control: T;
 }

--- a/libs/forms/core/src/dyn-control.class.ts
+++ b/libs/forms/core/src/dyn-control.class.ts
@@ -14,6 +14,7 @@ import { DynControlParams } from './control-params.types';
 import { DynControlParent, DynControlType, DynInstanceType } from './control.types';
 import { DynFormFactory } from './form.factory';
 import { DynFormNode } from './form.node';
+import { DynLogger } from './logger';
 
 @Directive()
 export abstract class DynControl<
@@ -37,21 +38,22 @@ export abstract class DynControl<
   control!: TControl; // built from the config by the abstract classes
   params!: TParams; // values available for the concrete Component instance
 
+  protected _logger: DynLogger;
   protected _fform: DynFormFactory;
   protected _ref: ChangeDetectorRef;
   protected _paramsChanged = new Subject<void>();
   protected _unsubscribe = new Subject<void>();
 
   constructor(injector: Injector) {
+    this._logger = injector.get(DynLogger);
+
     this.node = injector.get(DynFormNode);
     try {
       this.parent = injector.get(ControlContainer) as DynControlParent;
     } catch (e) {
-      throw new Error(
-        'No parent ControlContainer found. ' +
-        'Please provide a [formGroup]'
-      ); // TODO debug trace
+      throw this._logger.orphanControl();
     }
+
     this._fform = injector.get(DynFormFactory);
     this._ref = injector.get(ChangeDetectorRef);
   }

--- a/libs/forms/core/src/dyn-control.class.ts
+++ b/libs/forms/core/src/dyn-control.class.ts
@@ -31,7 +31,7 @@ export abstract class DynControl<
   // optional method for modules providing a typed factory method
   // abstract static createConfig(partial?: DynPartialControlConfig<TParams>): TConfig;
 
-  node: DynFormNode; // node service
+  node: DynFormNode<TControl>; // node service
   parent: DynControlParent; // typed ControlContainer
 
   config!: TConfig; // passed down in the hierarchy

--- a/libs/forms/core/src/dyn-control.class.ts
+++ b/libs/forms/core/src/dyn-control.class.ts
@@ -5,13 +5,13 @@ import {
   OnDestroy,
   OnInit,
 } from '@angular/core';
-import { AbstractControl, ControlContainer, FormGroup } from '@angular/forms';
+import { AbstractControl, FormGroup } from '@angular/forms';
 import { isObservable, Observable, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { DynBaseConfig } from './config.types';
 import { DynControlMode } from './control-mode.types';
 import { DynControlParams } from './control-params.types';
-import { DynControlParent, DynControlType, DynInstanceType } from './control.types';
+import { DynControlType, DynInstanceType } from './control.types';
 import { DynFormFactory } from './form.factory';
 import { DynFormNode } from './form.node';
 import { DynLogger } from './logger';
@@ -31,31 +31,24 @@ export abstract class DynControl<
   // optional method for modules providing a typed factory method
   // abstract static createConfig(partial?: DynPartialControlConfig<TParams>): TConfig;
 
-  node: DynFormNode<TControl>; // node service
-  parent: DynControlParent; // typed ControlContainer
+  node: DynFormNode<TControl>; // corresponding node
 
   config!: TConfig; // passed down in the hierarchy
   control!: TControl; // built from the config by the abstract classes
   params!: TParams; // values available for the concrete Component instance
 
   protected _logger: DynLogger;
-  protected _fform: DynFormFactory;
+  protected _formFactory: DynFormFactory;
   protected _ref: ChangeDetectorRef;
   protected _paramsChanged = new Subject<void>();
   protected _unsubscribe = new Subject<void>();
 
   constructor(injector: Injector) {
     this._logger = injector.get(DynLogger);
+    this._formFactory = injector.get(DynFormFactory);
+    this._ref = injector.get(ChangeDetectorRef);
 
     this.node = injector.get(DynFormNode);
-    try {
-      this.parent = injector.get(ControlContainer) as DynControlParent;
-    } catch (e) {
-      throw this._logger.orphanControl();
-    }
-
-    this._fform = injector.get(DynFormFactory);
-    this._ref = injector.get(ChangeDetectorRef);
   }
 
   ngOnInit(): void {

--- a/libs/forms/core/src/dyn-form-array.class.ts
+++ b/libs/forms/core/src/dyn-form-array.class.ts
@@ -7,7 +7,6 @@ import { DynInstanceType } from './control.types';
 import { DynControl } from './dyn-control.class';
 
 @Directive()
-// concrete arrays need to provide DynFormNode
 export abstract class DynFormArray<
     TMode extends DynControlMode = DynControlMode,
     TParams extends DynControlParams = DynControlParams,
@@ -23,18 +22,21 @@ export abstract class DynFormArray<
       throw this._logger.unnamedArray(this.config.control);
     }
 
-    // register the control first
+    // register the control
     this.control = this._fform.register(
       DynInstanceType.Array,
       this.config,
       this.parent
     );
 
-    // provide the parameters second
+    // provide the parameters
     super.ngOnInit();
 
-    // initialize the node at the end
-    this.node.init(this.config);
+    // initialize the node
+    this.node.init(this.config, this.control);
+
+    // log the successful initialization
+    this._logger.nodeInit('dyn-form-array', this.node.path, this.config.control);
   }
 
   addItem(): void {

--- a/libs/forms/core/src/dyn-form-array.class.ts
+++ b/libs/forms/core/src/dyn-form-array.class.ts
@@ -20,7 +20,7 @@ export abstract class DynFormArray<
   // auto-register in the form hierarchy
   ngOnInit(): void {
     if (!this.config.name) {
-      throw new Error(`No config.name provided for ${this.config.control}`);
+      throw this._logger.unnamedArray(this.config.control);
     }
 
     // register the control first

--- a/libs/forms/core/src/dyn-form-array.class.ts
+++ b/libs/forms/core/src/dyn-form-array.class.ts
@@ -23,10 +23,10 @@ export abstract class DynFormArray<
     }
 
     // register the control
-    this.control = this._fform.register(
+    this.control = this._formFactory.register(
       DynInstanceType.Array,
       this.config,
-      this.parent
+      this.node.parent,
     );
 
     // provide the parameters
@@ -41,7 +41,7 @@ export abstract class DynFormArray<
 
   addItem(): void {
     this.control.push(
-      this._fform.build(DynInstanceType.Group, this.config, true)
+      this._formFactory.build(DynInstanceType.Group, this.config, true)
     );
   }
 

--- a/libs/forms/core/src/dyn-form-container.class.ts
+++ b/libs/forms/core/src/dyn-form-container.class.ts
@@ -18,7 +18,7 @@ export abstract class DynFormContainer<
 
   // auto-register in the form hierarchy
   ngOnInit(): void {
-    // register the control first
+    // register the control
     if (this.config.name) {
       this.control = this._fform.register(
         DynInstanceType.Container,
@@ -30,10 +30,13 @@ export abstract class DynFormContainer<
       this.control = this.parent.control;
     }
 
-    // provide the parameters second
+    // provide the parameters
     super.ngOnInit();
 
-    // initialize the node at the end
-    this.node.init(this.config);
+    // initialize the node
+    this.node.init(this.config, this.control);
+
+    // log the successful initialization
+    this._logger.nodeInit('dyn-form-container', this.node.path, this.config.control);
   }
 }

--- a/libs/forms/core/src/dyn-form-container.class.ts
+++ b/libs/forms/core/src/dyn-form-container.class.ts
@@ -20,14 +20,14 @@ export abstract class DynFormContainer<
   ngOnInit(): void {
     // register the control
     if (this.config.name) {
-      this.control = this._fform.register(
+      this.control = this._formFactory.register(
         DynInstanceType.Container,
         this.config,
-        this.parent
+        this.node.parent,
       );
     } else if (!this.control) {
       // fallback to the parent control
-      this.control = this.parent.control;
+      this.control = this.node.parent.control;
     }
 
     // provide the parameters

--- a/libs/forms/core/src/dyn-form-control.class.ts
+++ b/libs/forms/core/src/dyn-form-control.class.ts
@@ -23,10 +23,10 @@ export abstract class DynFormControl<
     }
 
     // register the control
-    this.control = this._fform.register(
+    this.control = this._formFactory.register(
       DynInstanceType.Control,
       this.config,
-      this.parent
+      this.node.parent,
     );
 
     // provide the parameters

--- a/libs/forms/core/src/dyn-form-control.class.ts
+++ b/libs/forms/core/src/dyn-form-control.class.ts
@@ -22,14 +22,20 @@ export abstract class DynFormControl<
       throw new Error(`No config.name provided for ${this.config.control}`);
     }
 
-    // register the control first
+    // register the control
     this.control = this._fform.register(
       DynInstanceType.Control,
       this.config,
       this.parent
     );
 
-    // provide the parameters second
+    // provide the parameters
     super.ngOnInit();
+
+    // initialize the node
+    this.node.init(this.config, this.control);
+
+    // log the successful initialization
+    this._logger.nodeInit('dyn-form-control', this.node.path, this.config.control);
   }
 }

--- a/libs/forms/core/src/dyn-form-group.class.ts
+++ b/libs/forms/core/src/dyn-form-group.class.ts
@@ -20,14 +20,14 @@ export abstract class DynFormGroup<
   ngOnInit(): void {
     // register the control
     if (this.config.name) {
-      this.control = this._fform.register(
+      this.control = this._formFactory.register(
         DynInstanceType.Group,
         this.config,
-        this.parent
+        this.node.parent,
       );
     } else if (!this.control) {
       // fallback to the parent control (useful for UI subgroups)
-      this.control = this.parent.control;
+      this.control = this.node.parent.control;
     }
 
     // provide the parameters

--- a/libs/forms/core/src/dyn-form-group.class.ts
+++ b/libs/forms/core/src/dyn-form-group.class.ts
@@ -18,7 +18,7 @@ export abstract class DynFormGroup<
 
   // auto-register in the form hierarchy
   ngOnInit(): void {
-    // register the control first
+    // register the control
     if (this.config.name) {
       this.control = this._fform.register(
         DynInstanceType.Group,
@@ -30,10 +30,13 @@ export abstract class DynFormGroup<
       this.control = this.parent.control;
     }
 
-    // provide the parameters second
+    // provide the parameters
     super.ngOnInit();
 
-    // initialize the node at the end
-    this.node.init(this.config);
+    // initialize the node
+    this.node.init(this.config, this.control);
+
+    // log the successful initialization
+    this._logger.nodeInit('dyn-form-group', this.node.path, this.config.control);
   }
 }

--- a/libs/forms/core/src/form.factory.ts
+++ b/libs/forms/core/src/form.factory.ts
@@ -6,7 +6,8 @@ import {
   FormGroup,
 } from '@angular/forms';
 import { DynBaseConfig } from './config.types';
-import { DynControlParent, DynInstanceType } from './control.types';
+import { DynInstanceType } from './control.types';
+import { DynFormNode } from './form.node';
 import { DynFormRegistry } from './form.registry';
 
 @Injectable()
@@ -19,25 +20,25 @@ export class DynFormFactory {
   register(
     instance: DynInstanceType.Container | DynInstanceType.Group,
     config: DynBaseConfig,
-    parent: DynControlParent,
+    parent: DynFormNode,
     recursively?: boolean
   ): FormGroup;
   register(
     instance: DynInstanceType.Array,
     config: DynBaseConfig,
-    parent: DynControlParent,
+    parent: DynFormNode,
     recursively?: boolean
   ): FormArray;
   register(
     instance: DynInstanceType.Control,
     config: DynBaseConfig,
-    parent: DynControlParent,
+    parent: DynFormNode,
     recursively?: boolean
   ): FormControl;
   register<T extends AbstractControl>(
     instance: DynInstanceType,
     config: DynBaseConfig,
-    parent: DynControlParent,
+    parent: DynFormNode,
     recursively = false
   ): T {
     // fail-safe validation
@@ -125,7 +126,7 @@ export class DynFormFactory {
   /**
    * Append a control to a given parent in the specified name.
    */
-  append(parent: DynControlParent, name: string, control: AbstractControl) {
+  append(parent: DynFormNode, name: string, control: AbstractControl): void {
     // only FormGroup can be extended
     if (parent.control instanceof FormGroup) {
       parent.control.addControl(name, control);

--- a/libs/forms/core/src/form.node.ts
+++ b/libs/forms/core/src/form.node.ts
@@ -1,5 +1,5 @@
 import { Injectable, Optional, SkipSelf } from '@angular/core';
-import { AbstractControl, FormArray, FormGroup } from '@angular/forms';
+import { AbstractControl, FormGroup } from '@angular/forms';
 import { DynBaseConfig } from './config.types';
 import { DynLogger } from './logger';
 
@@ -20,7 +20,7 @@ export class DynFormNode<TControl extends AbstractControl = FormGroup>{
   constructor(
     private logger: DynLogger,
     // parent node should be set for all except the root
-    @Optional() @SkipSelf() private parent?: DynFormNode,
+    @Optional() @SkipSelf() public parent: DynFormNode,
   ) {}
 
   init(config: Partial<DynBaseConfig>, control: TControl): void {

--- a/libs/forms/core/src/form.node.ts
+++ b/libs/forms/core/src/form.node.ts
@@ -1,13 +1,14 @@
 import { Injectable, Optional, SkipSelf } from '@angular/core';
-import { AbstractControl, ControlContainer, FormGroupDirective } from '@angular/forms';
+import { AbstractControl, FormArray, FormGroup } from '@angular/forms';
 import { DynBaseConfig } from './config.types';
 import { DynLogger } from './logger';
 
 @Injectable()
 // initialized by dyn-form, dyn-factory, dyn-group
 // and the abstract DynControl* classes
-export class DynFormNode {
+export class DynFormNode<TControl extends AbstractControl = FormGroup>{
   name?: string;
+  control!: TControl;
 
   get path(): string[] {
     return [
@@ -16,30 +17,22 @@ export class DynFormNode {
     ].filter(Boolean);
   }
 
-  get form(): AbstractControl {
-    // the corresponding form could be lazy-filled
-    const form = (this.container as FormGroupDirective).form;
-    return this.name ? form.get(this.name) as AbstractControl : form;
-  }
-
   constructor(
-    private container: ControlContainer,
     private logger: DynLogger,
     // parent node should be set for all except the root
     @Optional() @SkipSelf() private parent?: DynFormNode,
   ) {}
 
-  init(config: Partial<DynBaseConfig>): void {
+  init(config: Partial<DynBaseConfig>, control: TControl): void {
     // throw error if the name is already set and different to the incoming one
     if (this.name !== undefined && this.name !== (config.name ?? '')) {
       return this.logger.nodeFailed(config.control);
     }
 
-    // construct the path
+    // register the name to build the form path
     this.name = config.name ?? '';
 
-    // TODO initialize control validators from name:args, on AfterViewInit?
-
-    this.logger.nodeInit(this.path, config.control);
+    // register the control created by the FormFactory
+    this.control = control;
   }
 }

--- a/libs/forms/core/src/logger/log-driver.service.ts
+++ b/libs/forms/core/src/logger/log-driver.service.ts
@@ -9,7 +9,7 @@ import { DynLog } from './log.interface';
 @Injectable()
 export class DynLogDriver {
   logFatal = (event: DynLog) => {
-    console.error(...this.format(event));
+    return new Error(event.message);
   }
 
   logError = (event: DynLog) => {
@@ -50,14 +50,14 @@ export class DynLogDriver {
     @Inject(DYN_LOG_LEVEL) private level: DynLogLevel,
   ) {}
 
-  log(event: DynLog): void {
+  log(event: DynLog): any {
     // do not log anything on production
     // or below the configured limit
     if (!isDevMode() || event.level < this.level) {
       return;
     }
 
-    this.loggers[event.level](event);
+    return this.loggers[event.level](event);
   }
 
   private format(event: DynLog): any[] {

--- a/libs/forms/core/src/logger/logger.service.ts
+++ b/libs/forms/core/src/logger/logger.service.ts
@@ -9,15 +9,6 @@ export class DynLogger {
     private driver: DynLogDriver,
   ) {}
 
-  orphanControl(): Error {
-    return this.driver.log({
-      level: DynLogLevel.Fatal,
-      message:
-        'No parent ControlContainer found. ' +
-        'Please provide a [formGroup]',
-    });
-  }
-
   unnamedArray(control: string): Error {
     return this.driver.log({
       level: DynLogLevel.Fatal,

--- a/libs/forms/core/src/logger/logger.service.ts
+++ b/libs/forms/core/src/logger/logger.service.ts
@@ -37,9 +37,9 @@ export class DynLogger {
   nodeInit(origin: string, path: string[], control?: string): void {
     this.driver.log({
       level: DynLogLevel.Verbose,
-      message: !path.join('.')
+      message: control === undefined && !path.join('.')
         ? `[${origin}] Root node initialized`
-        : `[${origin}] Node '${path.join('.')}' initialized ${control ? `(${control})` : ''}`,
+        : `[${origin}] initialized for '${path.join('.')}' ${control ? `(${control})` : ''}`,
     });
   }
 }

--- a/libs/forms/core/src/logger/logger.service.ts
+++ b/libs/forms/core/src/logger/logger.service.ts
@@ -9,21 +9,37 @@ export class DynLogger {
     private driver: DynLogDriver,
   ) {}
 
-  nodeFailed(control?: string): void {
-    this.driver.log({
+  orphanControl(): Error {
+    return this.driver.log({
       level: DynLogLevel.Fatal,
       message:
-        `Control '${control}' need to provide its own DynFormNode. ` +
-        `It is consuming the parent Node and that will cause unexpected effects.`
+        'No parent ControlContainer found. ' +
+        'Please provide a [formGroup]',
     });
   }
 
-  nodeInit(path: string[], control?: string): void {
+  unnamedArray(control: string): Error {
+    return this.driver.log({
+      level: DynLogLevel.Fatal,
+      message: `No config.name provided for ${control}`,
+    });
+  }
+
+  nodeFailed(control?: string): void {
+    this.driver.log({
+      level: DynLogLevel.Error,
+      message:
+        `Control '${control}' need to provide its own DynFormNode. ` +
+        `It is consuming the parent Node and that will cause unexpected effects.`,
+    });
+  }
+
+  nodeInit(origin: string, path: string[], control?: string): void {
     this.driver.log({
       level: DynLogLevel.Verbose,
       message: !path.join('.')
-        ? `Root node initialized`
-        : `Node '${path.join('.')}' initialized ${control ? `(${control})` : ''}`,
+        ? `[${origin}] Root node initialized`
+        : `[${origin}] Node '${path.join('.')}' initialized ${control ? `(${control})` : ''}`,
     });
   }
 }

--- a/libs/forms/material/src/components/array/array.component.ts
+++ b/libs/forms/material/src/components/array/array.component.ts
@@ -12,7 +12,6 @@ import {
   DynConfig,
   DynControlMode,
   DynFormArray,
-  DynFormNode,
   DynInstanceType,
   DynPartialControlConfig,
 } from '@myndpm/dyn-forms/core';
@@ -24,7 +23,6 @@ import { DynMatArrayParams } from './array.component.params';
   templateUrl: './array.component.html',
   styleUrls: ['./array.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [DynFormNode],
 })
 export class DynMatArrayComponent
   extends DynFormArray<DynControlMode, DynMatArrayParams, DynConfig>

--- a/libs/forms/material/src/components/card/card.component.ts
+++ b/libs/forms/material/src/components/card/card.component.ts
@@ -3,7 +3,6 @@ import {
   DynConfig,
   DynControlMode,
   DynFormContainer,
-  DynFormNode,
   DynPartialControlConfig,
 } from '@myndpm/dyn-forms/core';
 import { DynGroupComponent } from '@myndpm/dyn-forms';
@@ -14,7 +13,6 @@ import { DynMatCardParams } from './card.component.params';
   templateUrl: './card.component.html',
   styleUrls: ['./card.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [DynFormNode],
 })
 export class DynMatCardComponent
   extends DynFormContainer<DynControlMode, DynMatCardParams, DynConfig>

--- a/libs/forms/material/src/components/input/input.component.html
+++ b/libs/forms/material/src/components/input/input.component.html
@@ -1,4 +1,4 @@
-<ng-container [formGroup]="parent.control">
+<ng-container [formGroup]="node.parent.control">
   <mat-form-field [floatLabel]="params.readonly ? 'always' : params.floatLabel">
     <mat-label *ngIf="params.label">{{ params.label }}</mat-label>
     <input

--- a/libs/forms/material/src/components/radio/radio.component.html
+++ b/libs/forms/material/src/components/radio/radio.component.html
@@ -1,4 +1,4 @@
-<ng-container [formGroup]="parent.control">
+<ng-container [formGroup]="node.parent.control">
   <mat-radio-group [formControlName]="config.name">
     <mat-radio-button
       *ngFor="let option of params.options"

--- a/libs/forms/material/src/components/select/select.component.html
+++ b/libs/forms/material/src/components/select/select.component.html
@@ -1,4 +1,4 @@
-<ng-container [formGroup]="parent.control">
+<ng-container [formGroup]="node.parent.control">
   <mat-form-field>
     <mat-label *ngIf="params.label">{{ params.label }}</mat-label>
     <mat-select

--- a/libs/forms/src/lib/components/factory/factory.component.ts
+++ b/libs/forms/src/lib/components/factory/factory.component.ts
@@ -19,7 +19,6 @@ import {
   DynFormMode,
   DynFormNode,
   DynFormRegistry,
-  DynLogger,
   DYN_MODE,
 } from '@myndpm/dyn-forms/core';
 import deepEqual from 'fast-deep-equal';
@@ -30,7 +29,6 @@ import { BehaviorSubject } from 'rxjs';
   selector: 'dyn-factory',
   templateUrl: './factory.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [DynFormNode],
 })
 export class DynFactoryComponent implements OnInit {
   @Input() config!: DynBaseConfig;
@@ -55,22 +53,25 @@ export class DynFactoryComponent implements OnInit {
   constructor(
     @Inject(INJECTOR) private parent: Injector,
     private resolver: ComponentFactoryResolver,
-    private logger: DynLogger,
     private registry: DynFormRegistry,
-    private node: DynFormNode,
   ) {}
 
   ngOnInit(): void {
-    // initialize the form node
-    this.node.init(this.config);
-
-    // log the successful initialization
-    this.logger.nodeInit('dyn-factory', this.node.path, this.config.control);
-
     // resolve the injector to use and get providers
-    this._injector = this.injector ?? this.parent;
-    this._mode$ = this._injector.get(DYN_MODE);
-    this._formMode = this._injector.get(DynFormMode);
+    const injector = this.injector ?? this.parent;
+    this._mode$ = injector.get(DYN_MODE);
+    this._formMode = injector.get(DynFormMode);
+
+    this._injector = Injector.create({
+      providers: [
+        // abstract classes has its own DynFormNode
+        {
+          provide: DynFormNode,
+          useClass: DynFormNode,
+        },
+      ],
+      parent: injector,
+    });
 
     // create the dynamic component with each mode change
     let config: DynBaseConfig;

--- a/libs/forms/src/lib/components/factory/factory.component.ts
+++ b/libs/forms/src/lib/components/factory/factory.component.ts
@@ -19,6 +19,7 @@ import {
   DynFormMode,
   DynFormNode,
   DynFormRegistry,
+  DynLogger,
   DYN_MODE,
 } from '@myndpm/dyn-forms/core';
 import deepEqual from 'fast-deep-equal';
@@ -54,6 +55,7 @@ export class DynFactoryComponent implements OnInit {
   constructor(
     @Inject(INJECTOR) private parent: Injector,
     private resolver: ComponentFactoryResolver,
+    private logger: DynLogger,
     private registry: DynFormRegistry,
     private node: DynFormNode,
   ) {}
@@ -61,6 +63,9 @@ export class DynFactoryComponent implements OnInit {
   ngOnInit(): void {
     // initialize the form node
     this.node.init(this.config);
+
+    // log the successful initialization
+    this.logger.nodeInit('dyn-factory', this.node.path, this.config.control);
 
     // resolve the injector to use and get providers
     this._injector = this.injector ?? this.parent;

--- a/libs/forms/src/lib/components/form/form.component.ts
+++ b/libs/forms/src/lib/components/form/form.component.ts
@@ -18,6 +18,7 @@ import {
   DynControlMode,
   DynFormMode,
   DynFormNode,
+  DynLogger,
   DYN_MODE,
   DYN_MODE_CONTROL_DEFAULTS,
   DYN_MODE_DEFAULTS,
@@ -57,6 +58,7 @@ export class DynFormComponent implements OnInit, OnChanges, OnDestroy {
   constructor(
     @Inject(INJECTOR) private parent: Injector,
     private ref: ChangeDetectorRef,
+    private logger: DynLogger,
     private root: DynFormNode,
   ) {}
 
@@ -66,6 +68,7 @@ export class DynFormComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     this.root.init({});
+    this.logger.nodeInit('dyn-form', this.root.path);
 
     this.injector = Injector.create({
       parent: this.parent,

--- a/libs/forms/src/lib/components/form/form.component.ts
+++ b/libs/forms/src/lib/components/form/form.component.ts
@@ -67,7 +67,7 @@ export class DynFormComponent implements OnInit, OnChanges, OnDestroy {
       throw new Error(`Please provide a [form] to <dyn-form>`);
     }
 
-    this.root.init({});
+    this.root.init({}, this.form);
     this.logger.nodeInit('dyn-form', this.root.path);
 
     this.injector = Injector.create({

--- a/libs/forms/src/lib/components/group/group.component.ts
+++ b/libs/forms/src/lib/components/group/group.component.ts
@@ -6,7 +6,7 @@ import {
   ViewChildren,
 } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { DynBaseConfig, DynFormNode } from '@myndpm/dyn-forms/core';
+import { DynBaseConfig, DynFormNode, DynLogger } from '@myndpm/dyn-forms/core';
 import { DynFactoryComponent } from '../factory/factory.component';
 
 @Component({
@@ -26,11 +26,15 @@ export class DynGroupComponent {
   @ViewChildren(DynFactoryComponent) factories!: QueryList<DynFactoryComponent>;
 
   constructor(
+    private logger: DynLogger,
     private node: DynFormNode,
   ) {}
 
   ngOnInit(): void {
     this.node.init({ name: this.name });
+
+    // log the successful initialization
+    this.logger.nodeInit('dyn-group', this.node.path);
   }
 
   callHook(hook: string, payload: any, plainPayload = false): void {

--- a/libs/forms/src/lib/components/group/group.component.ts
+++ b/libs/forms/src/lib/components/group/group.component.ts
@@ -31,7 +31,7 @@ export class DynGroupComponent {
   ) {}
 
   ngOnInit(): void {
-    this.node.init({ name: this.name });
+    this.node.init({ name: this.name }, this.group);
 
     // log the successful initialization
     this.logger.nodeInit('dyn-group', this.node.path);


### PR DESCRIPTION
We had to manually build the Form Hierarchy because is not easy to use the FormDirectives to represent it in this dynamic approach. There will be a `DynFormNode` service attached to each control referencing and registering to its parent, just like the directives does inside `@angular/forms`.

With this service we will be able to centralize the responsibility of the control configuration (validators), and propagate events from the top to the bottom of the controls tree.