### PR TITLE
feat(ui-material): add MULTICKECK DynControl

### DIFF
--- a/libs/forms/ui-material/src/components/index.ts
+++ b/libs/forms/ui-material/src/components/index.ts
@@ -8,6 +8,8 @@ export * from './divider/divider.component';
 export * from './divider/divider.component.params';
 export * from './input/input.component';
 export * from './input/input.component.params';
+export * from './multicheckbox/multicheckbox.component';
+export * from './multicheckbox/multicheckbox.component.params';
 export * from './radio/radio.component';
 export * from './radio/radio.component.params';
 export * from './select/select.component';

--- a/libs/forms/ui-material/src/components/multicheckbox/multicheckbox.component.html
+++ b/libs/forms/ui-material/src/components/multicheckbox/multicheckbox.component.html
@@ -1,0 +1,7 @@
+<mat-label *ngIf="params.label">{{ params.label }}</mat-label>
+
+<div class="multicleck-option" *ngFor="let option of params.options; index as i">
+  <mat-checkbox [formControl]="controls[i]">
+    {{ option.text }}
+  </mat-checkbox>
+</div>

--- a/libs/forms/ui-material/src/components/multicheckbox/multicheckbox.component.params.ts
+++ b/libs/forms/ui-material/src/components/multicheckbox/multicheckbox.component.params.ts
@@ -1,0 +1,6 @@
+import { DynControlParams, DynOption } from '@myndpm/dyn-forms/core';
+
+export interface DynMatMulticheckboxParams extends DynControlParams {
+  label?: string;
+  options: DynOption[];
+}

--- a/libs/forms/ui-material/src/components/multicheckbox/multicheckbox.component.scss
+++ b/libs/forms/ui-material/src/components/multicheckbox/multicheckbox.component.scss
@@ -1,0 +1,10 @@
+:host {
+  display: block;
+  margin: .25em 0;
+  padding-bottom: 1.34375em; // spacing for mat-error
+
+  mat-label {
+    display: block;
+    margin-bottom: .25em;
+  }
+}

--- a/libs/forms/ui-material/src/components/multicheckbox/multicheckbox.component.spec.ts
+++ b/libs/forms/ui-material/src/components/multicheckbox/multicheckbox.component.spec.ts
@@ -1,0 +1,41 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { DynLogger } from '@myndpm/dyn-forms/logger';
+import { DynFormsModule } from '@myndpm/dyn-forms';
+import { DynFormNode, DYN_CONTROLS_TOKEN } from '@myndpm/dyn-forms/core';
+import { MockProvider } from 'ng-mocks';
+import { DynMatMulticheckboxComponent } from './multicheckbox.component';
+
+describe('DynMatMulticheckboxComponent', () => {
+  let component: DynMatMulticheckboxComponent;
+  let fixture: ComponentFixture<DynMatMulticheckboxComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        DynFormsModule.forFeature(),
+        MatCheckboxModule,
+      ],
+      declarations: [DynMatMulticheckboxComponent],
+      providers: [
+        MockProvider(DynLogger),
+        MockProvider(DynFormNode),
+        {
+          provide: DYN_CONTROLS_TOKEN,
+          useValue: {},
+          multi: true,
+        },
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DynMatMulticheckboxComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/forms/ui-material/src/components/multicheckbox/multicheckbox.component.ts
+++ b/libs/forms/ui-material/src/components/multicheckbox/multicheckbox.component.ts
@@ -1,0 +1,89 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnChanges,
+  OnInit,
+} from '@angular/core';
+import { FormControl } from '@angular/forms';
+import {
+  DynConfig,
+  DynControlMode,
+  DynFormControl,
+  DynPartialControlConfig,
+} from '@myndpm/dyn-forms/core';
+import { combineLatest } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { DynMatMulticheckboxParams } from './multicheckbox.component.params';
+
+@Component({
+  selector: 'dyn-mat-multicheckbox',
+  templateUrl: './multicheckbox.component.html',
+  styleUrls: ['./multicheckbox.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DynMatMulticheckboxComponent
+extends DynFormControl<DynControlMode, DynMatMulticheckboxParams>
+implements OnInit, OnChanges {
+
+  static dynControl: 'MULTICHECK' = 'MULTICHECK';
+
+  static createConfig<M extends DynControlMode>(
+    partial: DynPartialControlConfig<M, DynMatMulticheckboxParams>
+  ): DynConfig<M, DynMatMulticheckboxParams> {
+    return {
+      ...partial,
+      control: DynMatMulticheckboxComponent.dynControl,
+    };
+  }
+
+  controls: FormControl[] = [];
+
+  // avoids infinite loop emiting valueChange
+  private _internalValueChange = false;
+
+  ngOnInit(): void {
+    super.ngOnInit();
+
+    // listen valueChanges to sync the internal checkboxes
+    this.control.valueChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(() => {
+        if (!this._internalValueChange) {
+          this.params.options.forEach((option, i) => {
+            this.controls[i].setValue(this.hasValue(option.value));
+          });
+        }
+        this._internalValueChange = false;
+      });
+  }
+
+  ngOnChanges(): void {
+    // map one control to each option
+    this.controls = this.params.options.map((option) => {
+      return new FormControl(this.hasValue(option.value))
+    });
+
+    // listen the internal controls to sync the high-order control value
+    combineLatest(this.controls.map(({ valueChanges }) => valueChanges))
+      .pipe(takeUntil(this._paramsChanged))
+      .subscribe((values: boolean[]) => {
+        this._internalValueChange = true;
+        this.control.setValue(
+          values.map((enabled, i) => enabled ? this.params.options[i].value : null).filter(Boolean),
+        );
+      });
+  }
+
+  completeParams(params: Partial<DynMatMulticheckboxParams>): DynMatMulticheckboxParams {
+    return {
+      ...params,
+      options: params.options || [],
+    };
+  }
+
+  private hasValue(option: any): boolean {
+    return (
+      Array.isArray(this.control.value) ? this.control.value : []
+    ).includes(option);
+  }
+}

--- a/libs/forms/ui-material/src/dyn-forms-material.factory.ts
+++ b/libs/forms/ui-material/src/dyn-forms-material.factory.ts
@@ -16,6 +16,8 @@ import {
   DynMatDividerParams,
   DynMatInputComponent,
   DynMatInputParams,
+  DynMatMulticheckboxComponent,
+  DynMatMulticheckboxParams,
   DynMatRadioComponent,
   DynMatRadioParams,
   DynMatSelectComponent,
@@ -42,6 +44,10 @@ export function createMatConfig<M extends DynControlMode>(
 export function createMatConfig<M extends DynControlMode>(
   type: typeof DynMatInputComponent.dynControl,
   partial: DynPartialControlConfig<M, Partial<DynMatInputParams>>
+): DynConfig<M>;
+export function createMatConfig<M extends DynControlMode>(
+  type: typeof DynMatMulticheckboxComponent.dynControl,
+  partial: DynPartialControlConfig<M, Partial<DynMatMulticheckboxParams>>
 ): DynConfig<M>;
 export function createMatConfig<M extends DynControlMode>(
   type: typeof DynMatRadioComponent.dynControl,
@@ -71,6 +77,9 @@ export function createMatConfig<M extends DynControlMode>(
     // controls
     case DynMatCheckboxComponent.dynControl:
       return DynMatCheckboxComponent.createConfig(partial);
+
+    case DynMatMulticheckboxComponent.dynControl:
+      return DynMatMulticheckboxComponent.createConfig(partial);
 
     case DynMatSelectComponent.dynControl:
       return DynMatSelectComponent.createConfig(partial);

--- a/libs/forms/ui-material/src/dyn-forms-material.module.ts
+++ b/libs/forms/ui-material/src/dyn-forms-material.module.ts
@@ -17,6 +17,7 @@ import {
   DynMatCheckboxComponent,
   DynMatDividerComponent,
   DynMatInputComponent,
+  DynMatMulticheckboxComponent,
   DynMatRadioComponent,
   DynMatSelectComponent,
 } from './components';
@@ -42,6 +43,7 @@ import {
     DynMatCheckboxComponent,
     DynMatDividerComponent,
     DynMatInputComponent,
+    DynMatMulticheckboxComponent,
     DynMatRadioComponent,
     DynMatSelectComponent,
   ],
@@ -52,6 +54,7 @@ import {
     DynMatCheckboxComponent,
     DynMatDividerComponent,
     DynMatInputComponent,
+    DynMatMulticheckboxComponent,
     DynMatRadioComponent,
     DynMatSelectComponent,
   ],
@@ -90,6 +93,11 @@ export class DynFormsMaterialModule {
           control: DynMatInputComponent.dynControl,
           instance: DynMatInputComponent.dynInstance,
           component: DynMatInputComponent,
+        },
+        {
+          control: DynMatMulticheckboxComponent.dynControl,
+          instance: DynMatMulticheckboxComponent.dynInstance,
+          component: DynMatMulticheckboxComponent,
         },
         {
           control: DynMatRadioComponent.dynControl,


### PR DESCRIPTION
This PR illustrates the required work to add a `DynControl`.

`MULTICHECK` handles some internal FormControls
and updates the value of the configured `this.control` which updates the `dyn-form` values.