### PR TITLE
refactor: validators configurations as plain objects

### DIFF
--- a/apps/demos/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
+++ b/apps/demos/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
@@ -96,7 +96,7 @@ export function simpleForm(
           }),
           createMatConfig('INPUT', {
             name: 'zipCode',
-            options: { validators: { required: null, min: 0 } },
+            options: { validators: { required: null, minLength: 4 } },
             factory: { cssClass: 'col-sm-6 col-md-4' },
             params: { label: 'Postal Code *' },
           }),
@@ -139,7 +139,7 @@ export function simpleForm(
           }),
           createMatConfig('INPUT', {
             name: 'quantity',
-            options: { validators: { required: null, min: 1 } },
+            options: { validators: ['required', ['min', 1]] },
             factory: { cssClass: 'col-5 col-md-3' },
             params: { label: 'Quantity *', type: 'number' },
           }),

--- a/apps/demos/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
+++ b/apps/demos/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
@@ -69,7 +69,10 @@ export function simpleForm(
           }),
           createMatConfig('SELECT', {
             name: 'country',
-            options: { validators: ['required'] },
+            options: {
+              defaults: 'CO',
+              validators: ['required'],
+            },
             factory: { cssClass: 'col-sm-6 col-md-4' },
             params: {
               label: 'Country',

--- a/apps/demos/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
+++ b/apps/demos/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
@@ -1,4 +1,3 @@
-import { Validators } from '@angular/forms';
 import { DynControlParams } from '@myndpm/dyn-forms/core';
 import { createMatConfig, DynMatRadioParams, DynMatSelectParams } from '@myndpm/dyn-forms/ui-material';
 import { DynFormConfig } from '@myndpm/dyn-forms';
@@ -41,13 +40,13 @@ export function simpleForm(
         controls: [
           createMatConfig('INPUT', {
             name: 'firstName',
-            options: { validators: [Validators.required] },
+            options: { validators: ['required'] },
             factory: { cssClass: 'col-sm-6 col-md-4' },
             params: { label: 'First Name *' },
           }),
           createMatConfig('INPUT', {
             name: 'lastName',
-            options: { validators: [Validators.required] },
+            options: { validators: ['required'] },
             factory: { cssClass: 'col-sm-6 col-md-4' },
             params: { label: 'Last Name *' },
           }),
@@ -56,7 +55,7 @@ export function simpleForm(
           }),
           createMatConfig('INPUT', {
             name: 'address1',
-            options: { validators: [Validators.required] },
+            options: { validators: ['required'] },
             factory: { cssClass: 'col-12 col-md-8' },
             params: { label: 'Address Line 1 *' },
           }),
@@ -70,7 +69,7 @@ export function simpleForm(
           }),
           createMatConfig('SELECT', {
             name: 'country',
-            options: { validators: [Validators.required] },
+            options: { validators: ['required'] },
             factory: { cssClass: 'col-sm-6 col-md-4' },
             params: {
               label: 'Country',
@@ -97,7 +96,7 @@ export function simpleForm(
           }),
           createMatConfig('INPUT', {
             name: 'zipCode',
-            options: { validators: [Validators.required, Validators.min(0)] },
+            options: { validators: { required: null, min: 0 } },
             factory: { cssClass: 'col-sm-6 col-md-4' },
             params: { label: 'Postal Code *' },
           }),
@@ -134,13 +133,13 @@ export function simpleForm(
         controls: [
           createMatConfig('INPUT', {
             name: 'product',
-            options: { validators: [Validators.required] },
+            options: { validators: ['required'] },
             factory: { cssClass: 'col-6 col-md-8' },
             params: { label: 'Product Name *' },
           }),
           createMatConfig('INPUT', {
             name: 'quantity',
-            options: { validators: [Validators.required, Validators.min(1)] },
+            options: { validators: { required: null, min: 1 } },
             factory: { cssClass: 'col-5 col-md-3' },
             params: { label: 'Quantity *', type: 'number' },
           }),

--- a/apps/demos/src/app/demos/submodules/dyn-forms/components/stepper/stepper.form.ts
+++ b/apps/demos/src/app/demos/submodules/dyn-forms/components/stepper/stepper.form.ts
@@ -22,7 +22,7 @@ export function step1Form(): DynFormConfig {
           }),
           createMatConfig('INPUT', {
             name: 'phone',
-            options: { validators: { pattern: '/^[+]?\d*$/' } },
+            options: { validators: { pattern: /^[+]?\d*$/ } },
             factory: { cssClass: 'col-md-6' },
             params: {
               label: 'Phone',

--- a/apps/demos/src/app/demos/submodules/dyn-forms/components/stepper/stepper.form.ts
+++ b/apps/demos/src/app/demos/submodules/dyn-forms/components/stepper/stepper.form.ts
@@ -1,4 +1,3 @@
-import { Validators } from '@angular/forms';
 import { DynFormConfig } from '@myndpm/dyn-forms';
 import { createMatConfig } from '@myndpm/dyn-forms/ui-material';
 
@@ -11,19 +10,19 @@ export function step1Form(): DynFormConfig {
         controls: [
           createMatConfig('INPUT', {
             name: 'firstName',
-            options: { validators: [Validators.required] },
+            options: { validators: ['required'] },
             factory: { cssClass: 'col-sm-6' },
             params: { label: 'First Name *' },
           }),
           createMatConfig('INPUT', {
             name: 'lastName',
-            options: { validators: [Validators.required] },
+            options: { validators: ['required'] },
             factory: { cssClass: 'col-sm-6' },
             params: { label: 'Last Name *' },
           }),
           createMatConfig('INPUT', {
             name: 'phone',
-            options: { validators: [Validators.pattern(/^[+]?\d*$/)] },
+            options: { validators: { pattern: '/^[+]?\d*$/' } },
             factory: { cssClass: 'col-md-6' },
             params: {
               label: 'Phone',
@@ -68,7 +67,7 @@ export function step2Form(): DynFormConfig {
         controls: [
           createMatConfig('RADIO', {
             name: 'toc',
-            options: { validators: [Validators.required] },
+            options: { validators: ['required'] },
             params: {
               label: 'Do you accept the terms and conditions',
               options: [
@@ -79,7 +78,7 @@ export function step2Form(): DynFormConfig {
           }),
           createMatConfig('MULTICHECK', {
             name: 'choices',
-            options: { validators: [Validators.minLength(1)] },
+            options: { validators: { minLength: 1 } },
             params: {
               label: 'Select the applicable choices',
               options: [

--- a/libs/forms/core/index.ts
+++ b/libs/forms/core/index.ts
@@ -4,6 +4,7 @@ export * from './src/control-events.types';
 export * from './src/control-mode.types';
 export * from './src/control-params.types';
 export * from './src/control-provider.types';
+export * from './src/control-validation.types';
 export * from './src/control.types';
 export * from './src/option.types';
 export * from './src/tree.types';

--- a/libs/forms/core/src/control-config.types.ts
+++ b/libs/forms/core/src/control-config.types.ts
@@ -3,7 +3,7 @@ import { DynControlFactoryParams, DynControlParams } from './control-params.type
 import { DynControlTriggers } from './control-validation.types';
 import { DynControlType } from './control.types';
 
-export type DynConfigPrimitive = number | string | boolean;
+export type DynConfigPrimitive = number | string | boolean | object;
 
 // a plain/serializable value
 export type DynConfigArgs = DynConfigPrimitive | DynConfigPrimitive[] | null;
@@ -19,7 +19,7 @@ export type DynConfigCollection = { [id: string]: DynConfigArgs }
   single control options
  */
 export interface DynControlOptions extends DynControlTriggers {
-  defaults?: { // used on FormControls only
+  defaults?: DynConfigArgs | { // used on FormControls only
     value?: DynConfigArgs;
     disabled?: boolean;
   };

--- a/libs/forms/core/src/control-config.types.ts
+++ b/libs/forms/core/src/control-config.types.ts
@@ -3,7 +3,7 @@ import { DynControlFactoryParams, DynControlParams } from './control-params.type
 import { DynControlTriggers } from './control-validation.types';
 import { DynControlType } from './control.types';
 
-export type DynConfigPrimitive = number | string | boolean | object;
+export type DynConfigPrimitive = any; // FIXME omit functions?
 
 // a plain/serializable value
 export type DynConfigArgs = DynConfigPrimitive | DynConfigPrimitive[] | null;

--- a/libs/forms/core/src/control-config.types.ts
+++ b/libs/forms/core/src/control-config.types.ts
@@ -1,32 +1,42 @@
-import { AbstractControlOptions } from '@angular/forms';
 import { Observable } from 'rxjs';
 import { DynControlFactoryParams, DynControlParams } from './control-params.types';
+import { DynControlTriggers } from './control-validation.types';
 import { DynControlType } from './control.types';
 
-// single dynamic control config
+export type DynConfigPrimitive = number | string | boolean;
+
+// a plain/serializable value
+export type DynConfigArgs = DynConfigPrimitive | DynConfigPrimitive[] | null;
+
+// a given id to the functions
+export type DynConfigId = string;
+
+// a collection of ids with arguments to be used
+export type DynConfigCollection = { [id: string]: DynConfigArgs } | DynConfigId[];
+
+/**
+  single control options
+ */
+export interface DynControlOptions extends DynControlTriggers {
+  defaults?: { // used on FormControls only
+    value?: DynConfigArgs;
+    disabled?: boolean;
+  };
+  validators?: DynConfigCollection;
+  asyncValidators?: DynConfigCollection;
+  // errorHandlers?: DynConfigCollection;
+  // matchers?: DynControlMatcher[];
+}
+
+/**
+  single dynamic control config
+ */
 export interface DynControlConfig<TParams extends DynControlParams = DynControlParams> {
   // config
   control: DynControlType;
-  options?: AbstractControlOptions; // TODO remove when implement plain objects
-  /*
-  options?: {
-    defaults: {
-      value?: DynConfigArgs;
-      disabled?: boolean;
-    };
-    validators?: { [name: string]: DynConfigArgs; };
-    asyncValidators?: { [name: string]: DynConfigArgs; };
-    errorHandlers?: string[];
-    updateOn?: 'change' | 'blur' | 'submit';
-  };
-  */
+  options?: DynControlOptions;
   // customizations
   factory?: DynControlFactoryParams;
   params?: TParams | Observable<TParams>;
-  /*
-  // customized params functions
-  functions: {
-    [name: string]: DynConfigArgs;
-  }
-  */
+  // functions: DynConfigCollection;
 }

--- a/libs/forms/core/src/control-config.types.ts
+++ b/libs/forms/core/src/control-config.types.ts
@@ -12,7 +12,8 @@ export type DynConfigArgs = DynConfigPrimitive | DynConfigPrimitive[] | null;
 export type DynConfigId = string;
 
 // a collection of ids with arguments to be used
-export type DynConfigCollection = { [id: string]: DynConfigArgs } | DynConfigId[];
+export type DynConfigCollection = { [id: string]: DynConfigArgs }
+                                | Array<DynConfigId | [DynConfigId, DynConfigArgs]>;
 
 /**
   single control options

--- a/libs/forms/core/src/control-provider.types.ts
+++ b/libs/forms/core/src/control-provider.types.ts
@@ -5,6 +5,7 @@ import { DynControlMode } from './control-mode.types';
 import { DynControlParams } from './control-params.types';
 import { DynControlType, DynInstanceType } from './control.types';
 import { DynControl } from './dyn-control.class';
+import { DynBaseProvider } from './dyn-providers';
 
 export type AbstractDynControl = DynControl<
   DynControlMode,
@@ -13,7 +14,7 @@ export type AbstractDynControl = DynControl<
   AbstractControl
 >;
 
-export interface LazyControl {
+export interface LazyControl extends DynBaseProvider {
   control: DynControlType;
   instance: DynInstanceType;
   // resolved in DynFormRegistry
@@ -21,7 +22,7 @@ export interface LazyControl {
   component?: Type<AbstractDynControl>;
 }
 
-export interface InjectedControl {
+export interface InjectedControl extends DynBaseProvider {
   control: DynControlType;
   instance: DynInstanceType;
   component: Type<AbstractDynControl>;

--- a/libs/forms/core/src/control-validation.types.ts
+++ b/libs/forms/core/src/control-validation.types.ts
@@ -1,0 +1,7 @@
+/**
+ * triggers configuration
+ */
+ export interface DynControlTriggers {
+  invalidOn?: 'touched' | 'submitted';
+  updateOn?: 'change' | 'blur' | 'submit'; // Angular FormHooks
+}

--- a/libs/forms/core/src/control-validation.types.ts
+++ b/libs/forms/core/src/control-validation.types.ts
@@ -1,3 +1,7 @@
+import { AsyncValidatorFn, ValidatorFn } from '@angular/forms';
+import { DynConfigId } from './control-config.types';
+import { DynBaseProvider } from './dyn-providers';
+
 /**
  * triggers configuration
  */
@@ -5,3 +9,19 @@
   invalidOn?: 'touched' | 'submitted';
   updateOn?: 'change' | 'blur' | 'submit'; // Angular FormHooks
 }
+
+/**
+ * Base types
+ */
+export type DynValidatorFactory<T> = (...args: any[]) => T;
+
+/**
+ * validators provided in the module individually
+ */
+export interface DynBaseValidatorProvider<T> extends DynBaseProvider {
+  id: DynConfigId;
+  fn: DynValidatorFactory<T>;
+}
+
+export type DynValidatorProvider = DynBaseValidatorProvider<ValidatorFn>;
+export type DynAsyncValidatorProvider = DynBaseValidatorProvider<AsyncValidatorFn>;

--- a/libs/forms/core/src/control.types.ts
+++ b/libs/forms/core/src/control.types.ts
@@ -7,5 +7,3 @@ export enum DynInstanceType {
   Control = 'CONTROL',
   Container = 'CONTAINER',
 }
-
-// DynConfigArgs: any plain/serializable value

--- a/libs/forms/core/src/dyn-providers.ts
+++ b/libs/forms/core/src/dyn-providers.ts
@@ -1,0 +1,32 @@
+import { Validators } from '@angular/forms';
+import { DynValidatorProvider } from "./control-validation.types";
+
+/**
+ * Base provider
+ */
+export interface DynBaseProvider {
+  priority?: number;
+}
+
+/**
+ * Mapper to add the incoming priority
+ */
+ export function mapPriority<T extends DynBaseProvider>(priority?: number) {
+  return (item: T) => ({ ...item, priority: priority ?? item.priority ?? 0 });
+}
+
+/**
+ * Default Angular validators
+ */
+export const defaultValidators: DynValidatorProvider[] = [
+  { id: 'required', fn: () => Validators.required },
+  { id: 'requiredTrue', fn: () => Validators.requiredTrue },
+  { id: 'pattern', fn: Validators.pattern },
+  { id: 'minLength', fn: Validators.minLength },
+  { id: 'maxLength', fn: Validators.maxLength },
+  { id: 'email', fn: () => Validators.email },
+  { id: 'min', fn: Validators.min },
+  { id: 'max', fn: Validators.max },
+].map(
+  mapPriority<DynValidatorProvider>()
+);

--- a/libs/forms/core/src/form-factory.service.ts
+++ b/libs/forms/core/src/form-factory.service.ts
@@ -1,11 +1,13 @@
 import { Injectable } from '@angular/core';
 import {
   AbstractControl,
+  AbstractControlOptions,
   FormArray,
   FormControl,
   FormGroup,
 } from '@angular/forms';
 import { DynBaseConfig } from './config.types';
+import { DynConfigCollection, DynControlOptions } from './control-config.types';
 import { DynInstanceType } from './control.types';
 import { DynFormRegistry } from './form-registry.service';
 import { DynFormTreeNode } from './form-tree-node.service';
@@ -93,17 +95,22 @@ export class DynFormFactory {
     switch (instance) {
       case DynInstanceType.Container:
       case DynInstanceType.Group: {
-        const control = new FormGroup({}, config.options);
+        const control = new FormGroup({}, this.dynOptions(config.options));
         if (recursively) {
           this.buildControls(control, config);
         }
         return (control as unknown) as T;
       }
       case DynInstanceType.Array: {
-        return (new FormArray([], config.options) as unknown) as T;
+        return (new FormArray([], this.dynOptions(config.options)) as unknown) as T;
       }
       case DynInstanceType.Control: {
-        return (new FormControl(null, config.options) as unknown) as T;
+        return (
+          new FormControl(
+            config.options?.defaults ?? null,
+            this.dynOptions(config.options)
+          ) as unknown
+        ) as T;
       }
     }
   }
@@ -137,5 +144,26 @@ export class DynFormFactory {
     } else if (parent.control instanceof FormArray) {
       parent.control.push(control);
     }
+  }
+
+  /**
+   * Config translators
+   */
+  dynOptions(config?: DynControlOptions): AbstractControlOptions {
+    return {
+      validators: this.dynValidators(config?.validators),
+      asyncValidators: this.dynAsyncValidators(config?.asyncValidators),
+      updateOn: config?.updateOn,
+    }
+  }
+
+  dynValidators(config?: DynConfigCollection) { // TODO type return
+    // TODO process the validators
+    return null;
+  }
+
+  dynAsyncValidators(config?: DynConfigCollection) { // TODO type return
+    // TODO process the asyncValidators
+    return null;
   }
 }

--- a/libs/forms/core/src/form-factory.service.ts
+++ b/libs/forms/core/src/form-factory.service.ts
@@ -1,21 +1,23 @@
 import { Injectable } from '@angular/core';
 import {
   AbstractControl,
-  AbstractControlOptions,
   FormArray,
   FormControl,
   FormGroup,
 } from '@angular/forms';
 import { DynBaseConfig } from './config.types';
-import { DynConfigCollection, DynControlOptions } from './control-config.types';
 import { DynInstanceType } from './control.types';
 import { DynFormRegistry } from './form-registry.service';
 import { DynFormTreeNode } from './form-tree-node.service';
+import { DynFormValidators } from './form-validators.service';
 
 @Injectable()
 // injected in the DynControls to build their AbstractControls
 export class DynFormFactory {
-  constructor(private registry: DynFormRegistry) {}
+  constructor(
+    private registry: DynFormRegistry,
+    private validators: DynFormValidators,
+  ) {}
 
   /**
    * Adds a control (via config) to the given parent.
@@ -95,20 +97,20 @@ export class DynFormFactory {
     switch (instance) {
       case DynInstanceType.Container:
       case DynInstanceType.Group: {
-        const control = new FormGroup({}, this.dynOptions(config.options));
+        const control = new FormGroup({}, this.validators.dynOptions(config.options));
         if (recursively) {
           this.buildControls(control, config);
         }
         return (control as unknown) as T;
       }
       case DynInstanceType.Array: {
-        return (new FormArray([], this.dynOptions(config.options)) as unknown) as T;
+        return (new FormArray([], this.validators.dynOptions(config.options)) as unknown) as T;
       }
       case DynInstanceType.Control: {
         return (
           new FormControl(
             config.options?.defaults ?? null,
-            this.dynOptions(config.options)
+            this.validators.dynOptions(config.options)
           ) as unknown
         ) as T;
       }
@@ -144,26 +146,5 @@ export class DynFormFactory {
     } else if (parent.control instanceof FormArray) {
       parent.control.push(control);
     }
-  }
-
-  /**
-   * Config translators
-   */
-  dynOptions(config?: DynControlOptions): AbstractControlOptions {
-    return {
-      validators: this.dynValidators(config?.validators),
-      asyncValidators: this.dynAsyncValidators(config?.asyncValidators),
-      updateOn: config?.updateOn,
-    }
-  }
-
-  dynValidators(config?: DynConfigCollection) { // TODO type return
-    // TODO process the validators
-    return null;
-  }
-
-  dynAsyncValidators(config?: DynConfigCollection) { // TODO type return
-    // TODO process the asyncValidators
-    return null;
   }
 }

--- a/libs/forms/core/src/form-validators.service.ts
+++ b/libs/forms/core/src/form-validators.service.ts
@@ -1,0 +1,102 @@
+import { Inject, Injectable, Optional } from '@angular/core';
+import { AbstractControlOptions, AsyncValidatorFn, ValidatorFn } from '@angular/forms';
+import { DynLogger } from '@myndpm/dyn-forms/logger';
+import { DynConfigArgs, DynConfigCollection, DynConfigId, DynControlOptions } from './control-config.types';
+import { DynAsyncValidatorProvider, DynBaseValidatorProvider, DynValidatorFactory, DynValidatorProvider } from './control-validation.types';
+import { defaultValidators } from './dyn-providers';
+import { DYN_ASYNCVALIDATORS_TOKEN, DYN_VALIDATORS_TOKEN } from './form.tokens';
+
+@Injectable()
+// injected in the DynFormFactory to complete the controls options
+export class DynFormValidators {
+  // registered validators
+  validators = new Map<DynConfigId, DynValidatorFactory<ValidatorFn>>();
+  asyncValidators = new Map<DynConfigId, DynValidatorFactory<AsyncValidatorFn>>();
+
+  constructor(
+    private readonly logger: DynLogger,
+    @Inject(DYN_VALIDATORS_TOKEN) @Optional() readonly vals?: DynValidatorProvider[],
+    @Inject(DYN_ASYNCVALIDATORS_TOKEN) @Optional() readonly avals?: DynAsyncValidatorProvider[],
+  ) {
+    // reduce the provided validators according to priority
+    this.reduceProvider(
+      (this.vals ?? []).concat(defaultValidators), // add Angular's default validators
+      this.validators,
+    );
+    this.reduceProvider(
+      (this.avals ?? []),
+      this.asyncValidators,
+    );
+  }
+
+  /**
+   * Config translators
+   */
+  dynOptions(config?: DynControlOptions): AbstractControlOptions {
+    return {
+      validators: this.dynValidators(this.validators, config?.validators),
+      asyncValidators: this.dynValidators(this.asyncValidators, config?.asyncValidators),
+      updateOn: config?.updateOn,
+    }
+  }
+
+  private dynValidators<V>(
+    dictionary: Map<DynConfigId, DynValidatorFactory<V>>,
+    config?: DynConfigCollection,
+  ): V[]|null {
+    let validators: V[] = [];
+    if (Array.isArray(config)) {
+      // array of ids or [id, args]
+      validators = config.map(id => this.getValidatorFn(id, dictionary));
+    } else if (config) {
+      // object of { id: args }
+      Object.keys(config).forEach(id => {
+        validators.push(this.getValidatorFn([id, config[id]], dictionary))
+      });
+    }
+    return validators.length ? validators : null;
+  }
+
+  private getValidatorFn<V>(
+    id: DynConfigId | [DynConfigId, DynConfigArgs],
+    dictionary: Map<DynConfigId, DynValidatorFactory<V>>,
+  ): V {
+    if (Array.isArray(id)) {
+      const [vid, args] = id;
+      if (dictionary.has(vid)) {
+        return (dictionary.get(vid) as DynValidatorFactory<V>)(...this.getArgs(args));
+      }
+    } else if (dictionary.has(id)) {
+      return (dictionary.get(id) as DynValidatorFactory<V>)();
+    }
+    throw this.logger.validatorNotFound(id);
+  }
+
+  private getArgs(args: DynConfigArgs): DynConfigArgs[] {
+    return args ?? false
+      ? Array.isArray(args) ? args : [args]
+      : [];
+  }
+
+  private reduceProvider<T extends DynBaseValidatorProvider<any>, V>(
+    providers: T[],
+    dictionary: Map<DynConfigId, DynValidatorFactory<V>>,
+  ): void {
+    // FIXME validate the data-integrity of the incoming providers and throw logger
+    providers
+      .reduce(
+        // reduce the validators according to the priority
+        (map, validator) => {
+          if (!map.has(validator.id)
+          || ((validator.priority ?? 0) > (map.get(validator.id)?.priority ?? 0))) {
+            map.set(validator.id, validator);
+          }
+          return map;
+        },
+        new Map<DynConfigId, T>(),
+      ).forEach(validator => {
+        // keep only the ValidatorFn in the register
+        dictionary.set(validator.id, validator.fn);
+      });
+  }
+}

--- a/libs/forms/core/src/form.tokens.ts
+++ b/libs/forms/core/src/form.tokens.ts
@@ -2,21 +2,37 @@ import { InjectionToken } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { DynModeControls, DynModeParams, DynControlMode } from './control-mode.types';
 import { ControlProvider } from './control-provider.types';
+import { DynAsyncValidatorProvider, DynValidatorProvider } from './control-validation.types';
 
-// core token gathering the controls in the system
+/**
+ * core token gathering the controls in the system
+ */
 export const DYN_CONTROLS_TOKEN = new InjectionToken<ControlProvider[]>(
   '@myndpm/dyn-forms/dyn-controls'
 );
 
-// internal tokens managed by the dyn-form component
+/**
+ * core tokens for named functions
+ */
+export const DYN_VALIDATORS_TOKEN = new InjectionToken<DynValidatorProvider[]>(
+  '@myndpm/dyn-forms/validators'
+);
+
+export const DYN_ASYNCVALIDATORS_TOKEN = new InjectionToken<DynAsyncValidatorProvider[]>(
+  '@myndpm/dyn-forms/async-validators'
+);
+
+/**
+ * internal tokens managed by the dyn-form component
+ */
 export const DYN_MODE = new InjectionToken<BehaviorSubject<DynControlMode>>(
-  '@myndpm/dyn-forms/mode'
+  '@myndpm/dyn-forms/internal/mode'
 );
 
 export const DYN_MODE_DEFAULTS = new InjectionToken<DynModeParams>(
-  '@myndpm/dyn-forms/mode-defaults'
+  '@myndpm/dyn-forms/internal/mode-defaults'
 );
 
 export const DYN_MODE_CONTROL_DEFAULTS = new InjectionToken<DynModeControls>(
-  '@myndpm/dyn-forms/mode-control-defaults'
+  '@myndpm/dyn-forms/internal/mode-control-defaults'
 );

--- a/libs/forms/core/src/module.providers.ts
+++ b/libs/forms/core/src/module.providers.ts
@@ -1,16 +1,28 @@
 import { Provider } from '@angular/core';
 import { DynLogDriver, DynLogger, DynLogLevel, DYN_LOG_LEVEL } from '@myndpm/dyn-forms/logger';
 import { ControlProvider } from './control-provider.types';
+import { DynAsyncValidatorProvider, DynValidatorProvider } from './control-validation.types';
+import { mapPriority } from './dyn-providers';
 import { DynFormFactory } from './form-factory.service';
 import { DynFormRegistry } from './form-registry.service';
-import { DYN_CONTROLS_TOKEN } from './form.tokens';
+import { DynFormValidators } from './form-validators.service';
+import {
+  DYN_ASYNCVALIDATORS_TOKEN,
+  DYN_CONTROLS_TOKEN,
+  DYN_VALIDATORS_TOKEN,
+} from './form.tokens';
+
+export interface DynModuleProviders {
+  controls?: ControlProvider[];
+  providers?: Provider[];
+  validators?: DynValidatorProvider[];
+  asyncValidators?: DynAsyncValidatorProvider[];
+  priority?: number;
+}
 
 // utility used by DynFormsModule.forFeature
-export function getModuleProviders(
-  controls?: ControlProvider[],
-  providers?: Provider[],
-): Provider[] {
-  const baseProviders: Provider[] = [
+export function getModuleProviders(args?: DynModuleProviders): Provider[] {
+  return [
     {
       provide: DYN_LOG_LEVEL,
       useValue: DynLogLevel.Fatal,
@@ -18,23 +30,23 @@ export function getModuleProviders(
     DynLogDriver,
     DynLogger,
     DynFormRegistry,
+    DynFormValidators,
     DynFormFactory,
-  ];
-
-  if (!controls) {
-    return [
-      ...baseProviders,
-      ...providers ?? []
-    ];
-  }
-
-  return [
-    ...baseProviders,
-    ...providers ?? [],
-    ...controls.map((control) => ({
+    ...args?.providers ?? [],
+    ...args?.controls?.map(mapPriority(args?.priority)).map((control) => ({
       provide: DYN_CONTROLS_TOKEN,
       useValue: control,
       multi: true,
-    }))
+    })) ?? [],
+    ...args?.validators?.map(mapPriority(args?.priority)).map((validator) => ({
+      provide: DYN_VALIDATORS_TOKEN,
+      useValue: validator,
+      multi: true,
+    })) ?? [],
+    ...args?.asyncValidators?.map(mapPriority(args?.priority)).map((asyncValidator) => ({
+      provide: DYN_ASYNCVALIDATORS_TOKEN,
+      useValue: asyncValidator,
+      multi: true,
+    })) ?? [],
   ];
 }

--- a/libs/forms/lib/dyn-forms.module.interface.ts
+++ b/libs/forms/lib/dyn-forms.module.interface.ts
@@ -1,7 +1,0 @@
-import { Provider } from '@angular/core';
-import { ControlProvider } from '@myndpm/dyn-forms/core';
-
-export interface DynFormsModuleArgs {
-  providers?: Provider[];
-  controls: ControlProvider[];
-}

--- a/libs/forms/lib/dyn-forms.module.ts
+++ b/libs/forms/lib/dyn-forms.module.ts
@@ -1,9 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { ModuleWithProviders, NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { getModuleProviders } from '@myndpm/dyn-forms/core';
+import { DynModuleProviders, getModuleProviders } from '@myndpm/dyn-forms/core';
 import { DynFactoryComponent, DynFormComponent, DynGroupComponent } from './components';
-import { DynFormsModuleArgs } from './dyn-forms.module.interface';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule],
@@ -12,12 +11,12 @@ import { DynFormsModuleArgs } from './dyn-forms.module.interface';
 })
 export class DynFormsModule {
   static forFeature(
-    args?: DynFormsModuleArgs,
+    args?: DynModuleProviders,
     ngModule = DynFormsModule,
   ): ModuleWithProviders<DynFormsModule> {
     return {
       ngModule,
-      providers: getModuleProviders(args?.controls, args?.providers),
+      providers: getModuleProviders(args),
     };
   }
 }

--- a/libs/forms/logger/src/logger.service.ts
+++ b/libs/forms/logger/src/logger.service.ts
@@ -23,8 +23,15 @@ export class DynLogger {
     });
   }
 
-  nodeFailed(control?: string): void {
-    this.driver.log({
+  validatorNotFound(id: any): Error {
+    return this.driver.log({
+      level: DynLogLevel.Fatal,
+      message: `Validator '${id}' not provided.`,
+    });
+  }
+
+  nodeFailed(control?: string): Error {
+    return this.driver.log({
       level: DynLogLevel.Fatal,
       message:
         `Control '${control}' need to provide its own DynFormTreeNode. ` +
@@ -32,11 +39,10 @@ export class DynLogger {
     });
   }
 
-  nodeWithoutControl(): void {
-    this.driver.log({
+  nodeWithoutControl(): Error {
+    return this.driver.log({
       level: DynLogLevel.Fatal,
-      message:
-        `Could not resolve a control for the Node .`,
+      message: `Could not resolve a control for the Node .`,
     });
   }
 


### PR DESCRIPTION
Here the Work-In-Progress for the Validators + AsyncValidators + Matchers discussed here: https://github.com/myndpm/open-source/discussions/2