### PR TITLE
ui-native: building a ui-package

### DIFF
--- a/libs/forms/ui-native/index.ts
+++ b/libs/forms/ui-native/index.ts
@@ -1,0 +1,2 @@
+export * from './src/dyn-forms-native.module';
+export * from './src/components';

--- a/libs/forms/ui-native/index.ts
+++ b/libs/forms/ui-native/index.ts
@@ -1,2 +1,3 @@
 export * from './src/dyn-forms-native.module';
+export * from './src/dyn-forms-native.factory';
 export * from './src/components';

--- a/libs/forms/ui-native/ng-package.json
+++ b/libs/forms/ui-native/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/libs/forms/ui-native",
+  "lib": {
+    "entryFile": "./index.ts"
+  }
+}

--- a/libs/forms/ui-native/src/components/index.ts
+++ b/libs/forms/ui-native/src/components/index.ts
@@ -1,0 +1,2 @@
+export * from './input/input.component';
+export * from './input/input.component.params';

--- a/libs/forms/ui-native/src/components/input/input.component.html
+++ b/libs/forms/ui-native/src/components/input/input.component.html
@@ -1,0 +1,8 @@
+<ng-container [formGroup]="parentControl">
+  <label *ngIf="params.label">{{ params.label }}</label>
+
+  <input
+    [type]="params.type"
+    [formControlName]="config.name"
+  />
+</ng-container>

--- a/libs/forms/ui-native/src/components/input/input.component.params.ts
+++ b/libs/forms/ui-native/src/components/input/input.component.params.ts
@@ -1,0 +1,6 @@
+import { DynControlParams } from '@myndpm/dyn-forms/core';
+
+export interface DynNatInputParams extends DynControlParams {
+  type: 'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url';
+  label?: string;
+}

--- a/libs/forms/ui-native/src/components/input/input.component.scss
+++ b/libs/forms/ui-native/src/components/input/input.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/libs/forms/ui-native/src/components/input/input.component.spec.ts
+++ b/libs/forms/ui-native/src/components/input/input.component.spec.ts
@@ -1,0 +1,41 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { DynFormsModule } from '@myndpm/dyn-forms';
+import { DynFormTreeNode, DYN_CONTROLS_TOKEN } from '@myndpm/dyn-forms/core';
+import { DynLogger } from '@myndpm/dyn-forms/logger';
+import { MockProvider } from 'ng-mocks';
+import { DynNatInputComponent } from './input.component';
+
+describe('DynNatInputComponent', () => {
+  let component: DynNatInputComponent;
+  let fixture: ComponentFixture<DynNatInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        DynFormsModule.forFeature(),
+      ],
+      declarations: [DynNatInputComponent],
+      providers: [
+        MockProvider(DynLogger),
+        MockProvider(DynFormTreeNode),
+        {
+          provide: DYN_CONTROLS_TOKEN,
+          useValue: {},
+          multi: true,
+        },
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DynNatInputComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/forms/ui-native/src/components/input/input.component.ts
+++ b/libs/forms/ui-native/src/components/input/input.component.ts
@@ -1,0 +1,41 @@
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import {
+  DynConfig,
+  DynControlMode,
+  DynFormControl,
+  DynPartialControlConfig,
+} from '@myndpm/dyn-forms/core';
+import { DynNatInputParams } from './input.component.params';
+
+@Component({
+  selector: 'dyn-nat-input',
+  templateUrl: './input.component.html',
+  styleUrls: ['./input.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DynNatInputComponent
+extends DynFormControl<DynControlMode, DynNatInputParams>
+implements OnInit {
+
+  static dynControl: 'INPUT' = 'INPUT';
+
+  static createConfig<M extends DynControlMode>(
+    partial: DynPartialControlConfig<M, DynNatInputParams>
+  ): DynConfig<M> {
+    return {
+      ...partial,
+      control: DynNatInputComponent.dynControl,
+    };
+  }
+
+  ngOnInit(): void {
+    super.ngOnInit();
+  }
+
+  completeParams(params: Partial<DynNatInputParams>): DynNatInputParams {
+    return {
+      ...params,
+      type: params.type || 'text',
+    };
+  }
+}

--- a/libs/forms/ui-native/src/dyn-forms-native.factory.ts
+++ b/libs/forms/ui-native/src/dyn-forms-native.factory.ts
@@ -1,0 +1,29 @@
+import {
+  DynConfig,
+  DynControlMode,
+  DynControlType,
+  DynPartialControlConfig,
+} from '@myndpm/dyn-forms/core';
+import {
+  DynNatInputComponent,
+  DynNatInputParams,
+} from './components';
+
+// type overloads
+export function createMatConfig<M extends DynControlMode>(
+  type: typeof DynNatInputComponent.dynControl,
+  partial: DynPartialControlConfig<M, Partial<DynNatInputParams>>
+): DynConfig<M>;
+
+// factory
+export function createMatConfig<M extends DynControlMode>(
+  type: DynControlType,
+  partial: any,
+): DynConfig<M> {
+  switch (type) {
+    // controls
+    case DynNatInputComponent.dynControl:
+    default:
+      return DynNatInputComponent.createConfig(partial);
+  }
+}

--- a/libs/forms/ui-native/src/dyn-forms-native.module.ts
+++ b/libs/forms/ui-native/src/dyn-forms-native.module.ts
@@ -1,0 +1,28 @@
+import { CommonModule } from '@angular/common';
+import { ModuleWithProviders, NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { DynFormsModule } from '@myndpm/dyn-forms';
+import {
+} from './components';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    DynFormsModule,
+  ],
+  declarations: [
+  ],
+  exports: [
+    // reduce the boilerplate
+    DynFormsModule,
+  ]
+})
+export class DynFormsNativeModule {
+  static forFeature(): ModuleWithProviders<DynFormsNativeModule> {
+    return DynFormsModule.forFeature({
+      controls: [
+      ],
+    }, DynFormsNativeModule);
+  }
+}

--- a/libs/forms/ui-native/src/dyn-forms-native.module.ts
+++ b/libs/forms/ui-native/src/dyn-forms-native.module.ts
@@ -3,6 +3,7 @@ import { ModuleWithProviders, NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { DynFormsModule } from '@myndpm/dyn-forms';
 import {
+  DynNatInputComponent,
 } from './components';
 
 @NgModule({
@@ -12,6 +13,7 @@ import {
     DynFormsModule,
   ],
   declarations: [
+    DynNatInputComponent,
   ],
   exports: [
     // reduce the boilerplate
@@ -22,6 +24,11 @@ export class DynFormsNativeModule {
   static forFeature(): ModuleWithProviders<DynFormsNativeModule> {
     return DynFormsModule.forFeature({
       controls: [
+        {
+          control: DynNatInputComponent.dynControl,
+          instance: DynNatInputComponent.dynInstance,
+          component: DynNatInputComponent,
+        },
       ],
     }, DynFormsNativeModule);
   }


### PR DESCRIPTION
@moolsbytheway this PR has 2 commits:
1. creating a ui-package skeleton structure
2. adding a simple Native INPUT control

This `@myndpm/dyn-forms/ui-native` module can be used if you don't want to depend on any external UI framework, as mentioned in the discussion (https://github.com/myndpm/open-source/discussions/17), but it will need contributions to support many types of controls. Do you want to contribute? I'm already implementing flexible validators in another PR :)