### PR TITLE
feat: support Matchers and Conditions

### DIFF
--- a/apps/demos/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
+++ b/apps/demos/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
@@ -55,7 +55,7 @@ export function simpleForm(
           }),
           createMatConfig('INPUT', {
             name: 'address1',
-            options: { validators: ['required'] },
+            options: { validators: { required: null, minLength: 4 } },
             factory: { cssClass: 'col-12 col-md-8' },
             params: { label: 'Address Line 1 *' },
           }),
@@ -99,9 +99,16 @@ export function simpleForm(
           }),
           createMatConfig('INPUT', {
             name: 'zipCode',
-            options: { validators: { required: null, minLength: 4 } },
+            options: {
+              matchers: [
+                {
+                  match: 'DISABLE',
+                  when: [{ path: 'country', value: 'CO' }]
+                }
+              ]
+            },
             factory: { cssClass: 'col-sm-6 col-md-4' },
-            params: { label: 'Postal Code *' },
+            params: { label: 'Postal Code' },
           }),
         ],
       }),

--- a/apps/demos/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
+++ b/apps/demos/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
@@ -102,9 +102,13 @@ export function simpleForm(
             options: {
               matchers: [
                 {
-                  match: 'DISABLE',
-                  when: [{ path: 'country', value: 'CO' }]
-                }
+                  matcher: 'DISABLE',
+                  operator: 'OR',
+                  when: [
+                    { path: 'country', value: 'CO' },
+                    { path: 'firstName', value: 'M' },
+                  ]
+                },
               ]
             },
             factory: { cssClass: 'col-sm-6 col-md-4' },

--- a/apps/demos/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
+++ b/apps/demos/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
@@ -102,11 +102,12 @@ export function simpleForm(
             options: {
               matchers: [
                 {
-                  matcher: 'DISABLE',
-                  operator: 'OR',
+                  matcher: 'ENABLE',
+                  negate: true,
+                  operator: 'AND',
                   when: [
+                    { path: 'firstName', value: 'Mateo' },
                     { path: 'country', value: 'CO' },
-                    { path: 'firstName', value: 'M' },
                   ]
                 },
               ]

--- a/libs/forms/.eslintrc.json
+++ b/libs/forms/.eslintrc.json
@@ -20,7 +20,8 @@
         ],
         "@angular-eslint/directive-class-suffix": 0,
         "@typescript-eslint/no-empty-interface": 0,
-        "@typescript-eslint/no-explicit-any": 0
+        "@typescript-eslint/no-explicit-any": 0,
+        "@typescript-eslint/no-non-null-assertion": 0
       }
     },
     {

--- a/libs/forms/core/src/control-config.types.ts
+++ b/libs/forms/core/src/control-config.types.ts
@@ -1,15 +1,15 @@
 import { Observable } from 'rxjs';
+import { DynControlMatch } from './control-matchers.types';
 import { DynControlFactoryParams, DynControlParams } from './control-params.types';
 import { DynControlTriggers } from './control-validation.types';
 import { DynControlType } from './control.types';
 
-export type DynConfigPrimitive = any; // FIXME omit functions?
-
-// a plain/serializable value
-export type DynConfigArgs = DynConfigPrimitive | DynConfigPrimitive[] | null;
-
-// a given id to the functions
+// a given id to a validator/async-validator/error-handler/function
 export type DynConfigId = string;
+
+// plain/serializable arguments (no functions)
+export type DynConfigPrimitive = string | boolean | number | RegExp | { [k: string]: DynConfigPrimitive };
+export type DynConfigArgs = DynConfigPrimitive | DynConfigPrimitive[] | null;
 
 // a collection of ids with arguments to be used
 export type DynConfigCollection = { [id: string]: DynConfigArgs }
@@ -25,8 +25,8 @@ export interface DynControlOptions extends DynControlTriggers {
   };
   validators?: DynConfigCollection;
   asyncValidators?: DynConfigCollection;
+  matchers?: DynControlMatch[]; // conditional validations
   // errorHandlers?: DynConfigCollection;
-  // matchers?: DynControlMatcher[];
 }
 
 /**

--- a/libs/forms/core/src/control-config.types.ts
+++ b/libs/forms/core/src/control-config.types.ts
@@ -11,9 +11,10 @@ export type DynConfigId = string;
 export type DynConfigPrimitive = string | boolean | number | RegExp | { [k: string]: DynConfigPrimitive };
 export type DynConfigArgs = DynConfigPrimitive | DynConfigPrimitive[] | null;
 
-// a collection of ids with arguments to be used
-export type DynConfigCollection = { [id: string]: DynConfigArgs }
-                                | Array<DynConfigId | [DynConfigId, DynConfigArgs]>;
+// handlers provided can be referenced by id or [id with args]
+export type DynConfigProvider = DynConfigId | [DynConfigId, DynConfigArgs];
+// collection of handlers to be used
+export type DynConfigCollection = { [id: string]: DynConfigArgs } | Array<DynConfigProvider>;
 
 /**
   single control options

--- a/libs/forms/core/src/control-matchers.types.ts
+++ b/libs/forms/core/src/control-matchers.types.ts
@@ -1,0 +1,49 @@
+import { DynConfigArgs, DynConfigId } from './control-config.types';
+import { DynBaseProvider } from './dyn-providers';
+
+/**
+ * Base types
+ */
+export type DynMatcherFactory<F> = (...args: any[]) => F;
+
+export interface DynBaseMatcher<F> extends DynBaseProvider {
+  id: DynConfigId;
+  fn: DynMatcherFactory<F>;
+}
+
+export interface DynBaseCondition {
+  path: string; // queried relative to the control with the matcher
+}
+
+export interface DynControlMatchCondition extends DynBaseCondition {
+  id?: DynConfigId; // defaults to EQUAL condition
+  value?: DynConfigArgs;
+}
+
+/**
+ * match (condition) then run (matcher)
+ */
+ export interface DynControlMatch {
+  match: DynConfigId | [DynConfigId, DynConfigArgs]; // matcher ID | [id, args]
+  operator?: 'AND' | 'OR';
+  when: Array<DynConfigId | [DynConfigId, DynConfigArgs] | DynControlMatchCondition>;
+}
+
+/**
+ * matcher runs a feature:
+ *
+ * id: DISABLE | ENABLE | SHOW | HIDE | INVISIBLE | VALIDATE | etc
+ * fn: matcher action (node?) => ?
+ * FIXME type the fn
+ */
+export type DynControlMatcher = DynBaseMatcher<any>;
+
+/**
+ * conditions
+ * id: condition handler id
+ * fn:
+ *   provided: (node) => Observable<boolean>
+ *   match: object => [Observables] => boolean
+ * FIXME type the fn
+ */
+export type DynControlCondition = DynBaseMatcher<any>;

--- a/libs/forms/core/src/control-matchers.types.ts
+++ b/libs/forms/core/src/control-matchers.types.ts
@@ -1,5 +1,7 @@
+import { Observable } from 'rxjs';
 import { DynConfigArgs, DynConfigId } from './control-config.types';
 import { DynBaseProvider } from './dyn-providers';
+import { DynTreeNode } from './tree.types';
 
 /**
  * Base types
@@ -16,15 +18,16 @@ export interface DynBaseCondition {
 }
 
 export interface DynControlMatchCondition extends DynBaseCondition {
-  id?: DynConfigId; // defaults to EQUAL condition
+  id?: DynConfigId; // defaults to the DEFAULT condition handler
   value?: DynConfigArgs;
+  negation?: boolean; // negate the output of the handler
 }
 
 /**
  * match (condition) then run (matcher)
  */
  export interface DynControlMatch {
-  match: DynConfigId | [DynConfigId, DynConfigArgs]; // matcher ID | [id, args]
+  matcher: DynConfigId | [DynConfigId, DynConfigArgs]; // matcher id | [id, args]
   operator?: 'AND' | 'OR';
   when: Array<DynConfigId | [DynConfigId, DynConfigArgs] | DynControlMatchCondition>;
 }
@@ -46,4 +49,12 @@ export type DynControlMatcher = DynBaseMatcher<any>;
  *   match: object => [Observables] => boolean
  * FIXME type the fn
  */
-export type DynControlCondition = DynBaseMatcher<any>;
+export type DynControlConditionFn = (node: DynTreeNode) => Observable<boolean>;
+export type DynControlCondition = DynBaseMatcher<DynControlConditionFn>;
+
+/**
+ * type guard
+ */
+export function isBaseCondition(value: any): value is DynBaseCondition {
+  return !Array.isArray(value) && typeof value === 'object' && value.path;
+}

--- a/libs/forms/core/src/control-matchers.types.ts
+++ b/libs/forms/core/src/control-matchers.types.ts
@@ -20,7 +20,7 @@ export interface DynBaseCondition {
 export interface DynControlMatchCondition extends DynBaseCondition {
   id?: DynConfigId; // defaults to the DEFAULT condition handler
   value?: DynConfigArgs;
-  negation?: boolean; // negate the output of the handler
+  negate?: boolean; // negate the output of the handler
 }
 
 /**
@@ -28,6 +28,7 @@ export interface DynControlMatchCondition extends DynBaseCondition {
  */
  export interface DynControlMatch {
   matcher: DynConfigId | [DynConfigId, DynConfigArgs]; // matcher id | [id, args]
+  negate?: boolean; // use this matcher in the opposed way (ie. DISABLE -> ENABLE)
   operator?: 'AND' | 'OR';
   when: Array<DynConfigId | [DynConfigId, DynConfigArgs] | DynControlMatchCondition>;
 }

--- a/libs/forms/core/src/control-matchers.types.ts
+++ b/libs/forms/core/src/control-matchers.types.ts
@@ -37,8 +37,8 @@ export interface DynControlMatchCondition extends DynBaseCondition {
  *
  * id: DISABLE | ENABLE | SHOW | HIDE | INVISIBLE | VALIDATE | etc
  * fn: matcher action (node?) => ?
- * FIXME type the fn
  */
+export type DynControlMatcherFn = (node: DynTreeNode, hasMatch: boolean) => void;
 export type DynControlMatcher = DynBaseMatcher<any>;
 
 /**
@@ -47,7 +47,6 @@ export type DynControlMatcher = DynBaseMatcher<any>;
  * fn:
  *   provided: (node) => Observable<boolean>
  *   match: object => [Observables] => boolean
- * FIXME type the fn
  */
 export type DynControlConditionFn = (node: DynTreeNode) => Observable<boolean>;
 export type DynControlCondition = DynBaseMatcher<DynControlConditionFn>;

--- a/libs/forms/core/src/control-matchers.types.ts
+++ b/libs/forms/core/src/control-matchers.types.ts
@@ -1,17 +1,11 @@
 import { Observable } from 'rxjs';
 import { DynConfigArgs, DynConfigId, DynConfigProvider } from './control-config.types';
-import { DynBaseProvider } from './dyn-providers';
+import { DynBaseHandler } from './dyn-providers';
 import { DynTreeNode } from './tree.types';
 
 /**
  * Base types
  */
-export type DynMatcherFactory<F> = (...args: any[]) => F;
-
-export interface DynBaseMatcher<F> extends DynBaseProvider {
-  id: DynConfigId;
-  fn: DynMatcherFactory<F>;
-}
 
 export interface DynBaseCondition {
   path: string; // queried relative to the control with the matcher
@@ -34,23 +28,17 @@ export interface DynControlMatchCondition extends DynBaseCondition {
 }
 
 /**
- * matcher runs a feature:
- *
- * id: DISABLE | ENABLE | SHOW | HIDE | INVISIBLE | VALIDATE | etc
- * fn: matcher action (node?) => ?
+ * matcher handlers
+ * ie. DISABLE | ENABLE | SHOW | HIDE | INVISIBLE | etc
  */
 export type DynControlMatcherFn = (node: DynTreeNode, hasMatch: boolean) => void;
-export type DynControlMatcher = DynBaseMatcher<any>;
+export type DynControlMatcher = DynBaseHandler<DynControlMatcherFn>;
 
 /**
- * conditions
- * id: condition handler id
- * fn:
- *   provided: (node) => Observable<boolean>
- *   match: object => [Observables] => boolean
+ * condition handlers
  */
 export type DynControlConditionFn = (node: DynTreeNode) => Observable<boolean>;
-export type DynControlCondition = DynBaseMatcher<DynControlConditionFn>;
+export type DynControlCondition = DynBaseHandler<DynControlConditionFn>;
 
 /**
  * type guard

--- a/libs/forms/core/src/control-matchers.types.ts
+++ b/libs/forms/core/src/control-matchers.types.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs';
-import { DynConfigArgs, DynConfigId } from './control-config.types';
+import { DynConfigArgs, DynConfigId, DynConfigProvider } from './control-config.types';
 import { DynBaseProvider } from './dyn-providers';
 import { DynTreeNode } from './tree.types';
 
@@ -27,10 +27,10 @@ export interface DynControlMatchCondition extends DynBaseCondition {
  * match (condition) then run (matcher)
  */
  export interface DynControlMatch {
-  matcher: DynConfigId | [DynConfigId, DynConfigArgs]; // matcher id | [id, args]
+  matcher: DynConfigProvider; // matcher id | [id, args]
   negate?: boolean; // use this matcher in the opposed way (ie. DISABLE -> ENABLE)
   operator?: 'AND' | 'OR';
-  when: Array<DynConfigId | [DynConfigId, DynConfigArgs] | DynControlMatchCondition>;
+  when: Array<DynConfigProvider | DynControlMatchCondition>;
 }
 
 /**

--- a/libs/forms/core/src/control-validation.types.ts
+++ b/libs/forms/core/src/control-validation.types.ts
@@ -1,6 +1,5 @@
 import { AsyncValidatorFn, ValidatorFn } from '@angular/forms';
-import { DynConfigId } from './control-config.types';
-import { DynBaseProvider } from './dyn-providers';
+import { DynBaseHandler } from './dyn-providers';
 
 /**
  * triggers configuration
@@ -11,17 +10,7 @@ import { DynBaseProvider } from './dyn-providers';
 }
 
 /**
- * Base types
- */
-export type DynValidatorFactory<T> = (...args: any[]) => T;
-
-/**
  * validators provided in the module individually
  */
-export interface DynBaseValidatorProvider<T> extends DynBaseProvider {
-  id: DynConfigId;
-  fn: DynValidatorFactory<T>;
-}
-
-export type DynValidatorProvider = DynBaseValidatorProvider<ValidatorFn>;
-export type DynAsyncValidatorProvider = DynBaseValidatorProvider<AsyncValidatorFn>;
+export type DynValidatorProvider = DynBaseHandler<ValidatorFn>;
+export type DynAsyncValidatorProvider = DynBaseHandler<AsyncValidatorFn>;

--- a/libs/forms/core/src/dyn-control-node.class.ts
+++ b/libs/forms/core/src/dyn-control-node.class.ts
@@ -30,7 +30,7 @@ implements OnInit, OnDestroy {
     this._unsubscribe.complete();
 
     // remove it from the hierarchy
-    this.node.unregister();
+    this.node.onDestroy();
   }
 
   // propagate hook calls from the top to the bottom of the DynControls tree

--- a/libs/forms/core/src/dyn-form-array.class.ts
+++ b/libs/forms/core/src/dyn-form-array.class.ts
@@ -25,7 +25,7 @@ implements OnInit {
     }
 
     // initialize the node
-    this.node.register(DynInstanceType.Array, this.config);
+    this.node.onInit(DynInstanceType.Array, this.config);
 
     // provide the parameters
     super.ngOnInit();

--- a/libs/forms/core/src/dyn-form-container.class.ts
+++ b/libs/forms/core/src/dyn-form-container.class.ts
@@ -22,7 +22,7 @@ implements OnInit {
     // initialize the node
     if (!this.control) {
       // containers could have initialized the node differently
-      this.node.register(DynInstanceType.Container, this.config);
+      this.node.onInit(DynInstanceType.Container, this.config);
     }
 
     // provide the parameters

--- a/libs/forms/core/src/dyn-form-control.class.ts
+++ b/libs/forms/core/src/dyn-form-control.class.ts
@@ -24,7 +24,7 @@ implements OnInit {
     }
 
     // initialize the node
-    this.node.register(DynInstanceType.Control, this.config);
+    this.node.onInit(DynInstanceType.Control, this.config);
 
     // provide the parameters
     super.ngOnInit();

--- a/libs/forms/core/src/dyn-form-group.class.ts
+++ b/libs/forms/core/src/dyn-form-group.class.ts
@@ -20,7 +20,7 @@ implements OnInit {
   // auto-register in the form hierarchy
   ngOnInit(): void {
     // initialize the node
-    this.node.register(DynInstanceType.Group, this.config);
+    this.node.onInit(DynInstanceType.Group, this.config);
 
     // provide the parameters
     super.ngOnInit();

--- a/libs/forms/core/src/dyn-providers.ts
+++ b/libs/forms/core/src/dyn-providers.ts
@@ -67,7 +67,7 @@ export const defaultMatchers: DynControlMatcher[] = [
 export const defaultConditions: DynControlCondition[] = [
   {
     id: 'DEFAULT',
-    fn: ({ path, value, negation }: DynControlMatchCondition): DynControlConditionFn => {
+    fn: ({ path, value, negate }: DynControlMatchCondition): DynControlConditionFn => {
       return (node: DynTreeNode) => {
         const control = node.query(path);
         if (!control) {
@@ -83,7 +83,7 @@ export const defaultConditions: DynControlCondition[] = [
               : value === controlValue;
           }),
           // negate the result if needed
-          map(result => negation ? !result : result),
+          map(result => negate ? !result : result),
         );
       }
     }

--- a/libs/forms/core/src/dyn-providers.ts
+++ b/libs/forms/core/src/dyn-providers.ts
@@ -1,15 +1,23 @@
 import { Validators } from '@angular/forms';
 import { of } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
+import { DynConfigId } from './control-config.types';
 import { DynControlCondition, DynControlConditionFn, DynControlMatchCondition, DynControlMatcher, DynControlMatcherFn } from './control-matchers.types';
 import { DynValidatorProvider } from "./control-validation.types";
 import { DynTreeNode } from './tree.types';
 
 /**
- * Base provider
+ * Base types
  */
 export interface DynBaseProvider {
   priority?: number;
+}
+
+export type DynHandlerFactory<F> = (...args: any[]) => F;
+
+export interface DynBaseHandler<F> extends DynBaseProvider {
+  id: DynConfigId;
+  fn: DynHandlerFactory<F>;
 }
 
 /**

--- a/libs/forms/core/src/dyn-providers.ts
+++ b/libs/forms/core/src/dyn-providers.ts
@@ -11,7 +11,8 @@ export interface DynBaseProvider {
 /**
  * Mapper to add the incoming priority
  */
- export function mapPriority<T extends DynBaseProvider>(priority?: number) {
+export function mapPriority<T extends DynBaseProvider>(priority?: number) {
+  // TODO verify with real use-cases for the priority order
   return (item: T) => ({ ...item, priority: priority ?? item.priority ?? 0 });
 }
 

--- a/libs/forms/core/src/dyn-providers.ts
+++ b/libs/forms/core/src/dyn-providers.ts
@@ -1,7 +1,7 @@
 import { Validators } from '@angular/forms';
 import { of } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
-import { DynControlCondition, DynControlConditionFn, DynControlMatchCondition } from './control-matchers.types';
+import { DynControlCondition, DynControlConditionFn, DynControlMatchCondition, DynControlMatcher, DynControlMatcherFn } from './control-matchers.types';
 import { DynValidatorProvider } from "./control-validation.types";
 import { DynTreeNode } from './tree.types';
 
@@ -35,6 +35,31 @@ export const defaultValidators: DynValidatorProvider[] = [
 ].map(
   mapPriority<DynValidatorProvider>()
 );
+
+/**
+ * Default matchers
+ */
+export const defaultMatchers: DynControlMatcher[] = [
+  {
+    id: 'DISABLE',
+    fn: (): DynControlMatcherFn => {
+      return (node: DynTreeNode, hasMatch: boolean) => {
+        hasMatch ? node.control.disable() : node.control.enable();
+      }
+    }
+  },
+  {
+    id: 'ENABLE',
+    fn: (): DynControlMatcherFn => {
+      return (node: DynTreeNode, hasMatch: boolean) => {
+        hasMatch ? node.control.enable() : node.control.disable();
+      }
+    }
+  },
+].map(
+  mapPriority<DynControlMatcher>()
+);
+
 
 /**
  * Default condition handler

--- a/libs/forms/core/src/form-factory.service.ts
+++ b/libs/forms/core/src/form-factory.service.ts
@@ -52,7 +52,7 @@ export class DynFormFactory {
     }
 
     // return any existing control with this name
-    // TODO check if we have a parent FormArray
+    // TODO check if we have a parent FormArray with node.instance
     // assumes a parent FormGroup
     let control = config.name ? parent.control.get(config.name) : null;
     if (control) {

--- a/libs/forms/core/src/form-matchers.service.ts
+++ b/libs/forms/core/src/form-matchers.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Optional } from '@angular/core';
 import { DynLogger } from '@myndpm/dyn-forms/logger';
-import { DynConfigArgs, DynConfigId } from './control-config.types';
+import { DynConfigArgs, DynConfigId, DynConfigProvider } from './control-config.types';
 import {
   DynBaseMatcher,
   DynControlCondition,
@@ -39,9 +39,7 @@ export class DynFormMatchers {
     );
   }
 
-  getMatcher(
-    config: DynConfigId | [DynConfigId, DynConfigArgs],
-  ): DynControlMatcherFn {
+  getMatcher(config: DynConfigProvider): DynControlMatcherFn {
     if (Array.isArray(config)) {
       const [id, args] = config;
       if (this.matchers.has(id)) {
@@ -53,9 +51,7 @@ export class DynFormMatchers {
     throw this.logger.providerNotFound('Matcher', config);
   }
 
-  getCondition(
-    config: DynConfigId | [DynConfigId, DynConfigArgs] | DynControlMatchCondition,
-  ): DynControlConditionFn {
+  getCondition(config: DynConfigProvider | DynControlMatchCondition): DynControlConditionFn {
     if (Array.isArray(config)) {
       const [id, args] = config;
       if (this.conditions.has(id)) {

--- a/libs/forms/core/src/form-matchers.service.ts
+++ b/libs/forms/core/src/form-matchers.service.ts
@@ -2,24 +2,27 @@ import { Inject, Injectable, Optional } from '@angular/core';
 import { DynLogger } from '@myndpm/dyn-forms/logger';
 import { DynConfigArgs, DynConfigId, DynConfigProvider } from './control-config.types';
 import {
-  DynBaseMatcher,
   DynControlCondition,
   DynControlConditionFn,
   DynControlMatchCondition,
   DynControlMatcher,
   DynControlMatcherFn,
-  DynMatcherFactory,
   isBaseCondition,
 } from './control-matchers.types';
-import { defaultConditions, defaultMatchers } from './dyn-providers';
+import {
+  defaultConditions,
+  defaultMatchers,
+  DynBaseHandler,
+  DynHandlerFactory,
+} from './dyn-providers';
 import { DYN_MATCHERS_TOKEN, DYN_MATCHER_CONDITIONS_TOKEN } from './form.tokens';
 
 @Injectable()
 // injected in the DynFormTreeNode to manage matchers
 export class DynFormMatchers {
   // registered matchers and conditions
-  matchers = new Map<DynConfigId, DynMatcherFactory<DynControlMatcherFn>>();
-  conditions = new Map<DynConfigId, DynMatcherFactory<DynControlConditionFn>>();
+  matchers = new Map<DynConfigId, DynHandlerFactory<DynControlMatcherFn>>();
+  conditions = new Map<DynConfigId, DynHandlerFactory<DynControlConditionFn>>();
 
   constructor(
     private readonly logger: DynLogger,
@@ -74,9 +77,9 @@ export class DynFormMatchers {
       : [];
   }
 
-  private reduceProvider<T extends DynBaseMatcher<any>, V>(
+  private reduceProvider<T extends DynBaseHandler<any>, V>(
     providers: T[],
-    dictionary: Map<DynConfigId, DynMatcherFactory<V>>,
+    dictionary: Map<DynConfigId, DynHandlerFactory<V>>,
   ): void {
     // FIXME validate the data-integrity of the provided values and throw logger
     providers

--- a/libs/forms/core/src/form-matchers.service.ts
+++ b/libs/forms/core/src/form-matchers.service.ts
@@ -7,17 +7,18 @@ import {
   DynControlConditionFn,
   DynControlMatchCondition,
   DynControlMatcher,
+  DynControlMatcherFn,
   DynMatcherFactory,
   isBaseCondition,
 } from './control-matchers.types';
-import { defaultConditions } from './dyn-providers';
+import { defaultConditions, defaultMatchers } from './dyn-providers';
 import { DYN_MATCHERS_TOKEN, DYN_MATCHER_CONDITIONS_TOKEN } from './form.tokens';
 
 @Injectable()
 // injected in the DynFormTreeNode to manage matchers
 export class DynFormMatchers {
   // registered matchers and conditions
-  matchers = new Map<DynConfigId, DynMatcherFactory<any>>();
+  matchers = new Map<DynConfigId, DynMatcherFactory<DynControlMatcherFn>>();
   conditions = new Map<DynConfigId, DynMatcherFactory<DynControlConditionFn>>();
 
   constructor(
@@ -29,7 +30,7 @@ export class DynFormMatchers {
   ) {
     // reduce the provided validators according to priority
     this.reduceProvider(
-      (this.providedMatchers ?? []),
+      (this.providedMatchers ?? []).concat(defaultMatchers),
       this.matchers,
     );
     this.reduceProvider(
@@ -38,9 +39,9 @@ export class DynFormMatchers {
     );
   }
 
-  getMatcher<V>(
+  getMatcher(
     config: DynConfigId | [DynConfigId, DynConfigArgs],
-  ): V {
+  ): DynControlMatcherFn {
     if (Array.isArray(config)) {
       const [id, args] = config;
       if (this.matchers.has(id)) {

--- a/libs/forms/core/src/form-matchers.service.ts
+++ b/libs/forms/core/src/form-matchers.service.ts
@@ -1,0 +1,53 @@
+import { Inject, Injectable, Optional } from '@angular/core';
+import { DynLogger } from '@myndpm/dyn-forms/logger';
+import { DynConfigId } from './control-config.types';
+import { DynBaseMatcher, DynControlMatcher, DynControlCondition, DynMatcherFactory } from './control-matchers.types';
+import { DYN_MATCHERS_TOKEN, DYN_MATCHER_CONDITIONS_TOKEN } from './form.tokens';
+
+@Injectable()
+// injected in the DynFormTreeNode to manage matchers
+export class DynFormMatchers {
+  // registered matchers and conditions
+  matchers = new Map<DynConfigId, any>();
+  conditions = new Map<DynConfigId, any>();
+
+  constructor(
+    private readonly logger: DynLogger,
+    @Inject(DYN_MATCHERS_TOKEN) @Optional()
+    readonly providedMatchers?: DynControlMatcher[],
+    @Inject(DYN_MATCHER_CONDITIONS_TOKEN) @Optional()
+    readonly providedConditions?: DynControlCondition[],
+  ) {
+    // reduce the provided validators according to priority
+    this.reduceProvider(
+      (this.providedMatchers ?? []),
+      this.matchers,
+    );
+    this.reduceProvider(
+      (this.providedConditions ?? []),
+      this.conditions,
+    );
+  }
+
+  private reduceProvider<T extends DynBaseMatcher<any>, V>(
+    providers: T[],
+    dictionary: Map<DynConfigId, DynMatcherFactory<V>>,
+  ): void {
+    // FIXME validate the data-integrity of the provided values and throw logger
+    providers
+      .reduce(
+        // reduce the validators according to the priority
+        (map, validator) => {
+          if (!map.has(validator.id)
+          || ((validator.priority ?? 0) > (map.get(validator.id)?.priority ?? 0))) {
+            map.set(validator.id, validator);
+          }
+          return map;
+        },
+        new Map<DynConfigId, T>(),
+      ).forEach(validator => {
+        // keep only the fn in the register
+        dictionary.set(validator.id, validator.fn);
+      });
+  }
+}

--- a/libs/forms/core/src/form-registry.service.ts
+++ b/libs/forms/core/src/form-registry.service.ts
@@ -29,7 +29,7 @@ export class DynFormRegistry {
     return {
       control: resolved.control,
       instance: resolved.instance,
-      component: resolved.component ?? ({} as any),
+      component: resolved.component!,
     };
   }
 

--- a/libs/forms/core/src/form-tree-node.service.ts
+++ b/libs/forms/core/src/form-tree-node.service.ts
@@ -173,6 +173,8 @@ implements DynTreeNode<TControl> {
   afterViewInit(): void {
     // process the stored matchers
     this._matchers?.map((config) => {
+      const matcher = this.formMatchers.getMatcher(config.matcher);
+
       // build an array of observables to listen changes into
       const observables = config.when
         .map(condition => this.formMatchers.getCondition(condition)) // handler fn
@@ -187,8 +189,8 @@ implements DynTreeNode<TControl> {
           takeUntil(this._unsubscribe),
           distinctUntilChanged(),
         )
-        .subscribe(res => {
-          console.log('matcher', res)
+        .subscribe(hasMatch => {
+          matcher(this, hasMatch) // run the matcher with the match result
         });
     });
 

--- a/libs/forms/core/src/form-tree-node.service.ts
+++ b/libs/forms/core/src/form-tree-node.service.ts
@@ -73,8 +73,9 @@ implements DynTreeNode<TControl> {
 
   // query for a control upper in the tree
   query(path: string, searchNodes = false): AbstractControl|null {
-    let result: AbstractControl|null;
+    /* eslint-disable @typescript-eslint/no-this-alias */
     let node: DynFormTreeNode<AbstractControl> = this;
+    let result: AbstractControl|null;
 
     do {
       // query by form.control and by node.path

--- a/libs/forms/core/src/form-tree-node.service.ts
+++ b/libs/forms/core/src/form-tree-node.service.ts
@@ -18,7 +18,7 @@ export class DynFormTreeNode<TControl extends AbstractControl = FormGroup>
 implements DynTreeNode<TControl> {
   // form hierarchy
   isolated = false;
-  children: DynFormTreeNode[] = [];
+  children: DynFormTreeNode<AbstractControl>[] = [];
 
   // reactive events
   hook$ = new Subject<DynControlHook>();
@@ -216,13 +216,13 @@ implements DynTreeNode<TControl> {
   /**
    * Hierarchy methods
    */
-  private addChild(node: DynFormTreeNode<any>): void {
+  private addChild(node: DynFormTreeNode<AbstractControl>): void {
     this.children.push(node);
 
     // TODO setup validators
   }
 
-  private removeChild(node: DynFormTreeNode<any>): void {
+  private removeChild(node: DynFormTreeNode<AbstractControl>): void {
     this.children.some((child, i) => {
       return (child === node) ? this.children.splice(i, 1) : false;
     });

--- a/libs/forms/core/src/form-tree-node.service.ts
+++ b/libs/forms/core/src/form-tree-node.service.ts
@@ -98,6 +98,13 @@ export class DynFormTreeNode<TControl extends AbstractControl = FormGroup>{
     }
   }
 
+  afterViewInit(): void {
+    // process the stored matchers
+
+    // call the children
+    this.children.map(child => child.afterViewInit());
+  }
+
   onDestroy(): void {
     // TODO test unload with routed forms
 

--- a/libs/forms/core/src/form-tree-node.service.ts
+++ b/libs/forms/core/src/form-tree-node.service.ts
@@ -48,15 +48,7 @@ export class DynFormTreeNode<TControl extends AbstractControl = FormGroup>{
     @Optional() @SkipSelf() public readonly parent: DynFormTreeNode,
   ) {}
 
-  setControl(control: TControl, instance = DynInstanceType.Group): void {
-    this.logger.nodeControl();
-
-    // manual setup with no wiring nor config validation
-    this._instance = instance;
-    this._control = control;
-  }
-
-  register(instance: DynInstanceType, config: DynBaseConfig): void {
+  onInit(instance: DynInstanceType, config: DynBaseConfig): void {
     // throw error if the name is already set and different to the incoming one
     if (this.name !== undefined && this.name !== (config.name ?? '')) {
       throw this.logger.nodeFailed(config.control);
@@ -81,6 +73,14 @@ export class DynFormTreeNode<TControl extends AbstractControl = FormGroup>{
     this.load(config);
   }
 
+  setControl(control: TControl, instance = DynInstanceType.Group): void {
+    this.logger.nodeControl();
+
+    // manual setup with no wiring nor config validation
+    this._instance = instance;
+    this._control = control;
+  }
+
   load(config: Partial<DynBaseConfig>): void {
     if (!this._control) {
       throw this.logger.nodeWithoutControl();
@@ -98,7 +98,7 @@ export class DynFormTreeNode<TControl extends AbstractControl = FormGroup>{
     }
   }
 
-  unregister(): void {
+  onDestroy(): void {
     // TODO test unload with routed forms
 
     if (!this.isolated) {

--- a/libs/forms/core/src/form-tree-node.service.ts
+++ b/libs/forms/core/src/form-tree-node.service.ts
@@ -190,7 +190,8 @@ implements DynTreeNode<TControl> {
           distinctUntilChanged(),
         )
         .subscribe(hasMatch => {
-          matcher(this, hasMatch) // run the matcher with the match result
+          // run the matcher with the conditions result
+          matcher(this, config.negate ? !hasMatch : hasMatch)
         });
     });
 

--- a/libs/forms/core/src/form-tree-node.service.ts
+++ b/libs/forms/core/src/form-tree-node.service.ts
@@ -4,6 +4,7 @@ import { DynLogger } from '@myndpm/dyn-forms/logger';
 import { Subject } from 'rxjs';
 import { DynBaseConfig } from './config.types';
 import { DynControlHook } from './control-events.types';
+import { DynControlMatch } from './control-matchers.types';
 import { DynInstanceType } from './control.types';
 import { DynFormFactory } from './form-factory.service';
 
@@ -40,6 +41,7 @@ export class DynFormTreeNode<TControl extends AbstractControl = FormGroup>{
   private _name?: string;
   private _instance!: DynInstanceType;
   private _control!: TControl;
+  private _matchers?: DynControlMatch[];
 
   constructor(
     private readonly formFactory: DynFormFactory,
@@ -91,6 +93,9 @@ export class DynFormTreeNode<TControl extends AbstractControl = FormGroup>{
 
     // register the name to build the form path
     this._name = config.name ?? '';
+
+    // store the matchers to be processed afterViewInit
+    this._matchers = config.options?.matchers;
 
     if (!this.isolated) {
       // register the node with its parent

--- a/libs/forms/core/src/form-validators.service.ts
+++ b/libs/forms/core/src/form-validators.service.ts
@@ -1,17 +1,23 @@
 import { Inject, Injectable, Optional } from '@angular/core';
 import { AbstractControlOptions, AsyncValidatorFn, ValidatorFn } from '@angular/forms';
 import { DynLogger } from '@myndpm/dyn-forms/logger';
-import { DynConfigArgs, DynConfigCollection, DynConfigId, DynConfigProvider, DynControlOptions } from './control-config.types';
-import { DynAsyncValidatorProvider, DynBaseValidatorProvider, DynValidatorFactory, DynValidatorProvider } from './control-validation.types';
-import { defaultValidators } from './dyn-providers';
+import {
+  DynConfigArgs,
+  DynConfigCollection,
+  DynConfigId,
+  DynConfigProvider,
+  DynControlOptions,
+} from './control-config.types';
+import { DynAsyncValidatorProvider, DynValidatorProvider } from './control-validation.types';
+import { defaultValidators, DynBaseHandler, DynHandlerFactory } from './dyn-providers';
 import { DYN_ASYNCVALIDATORS_TOKEN, DYN_VALIDATORS_TOKEN } from './form.tokens';
 
 @Injectable()
 // injected in the DynFormFactory to complete the controls options
 export class DynFormValidators {
   // registered validators
-  validators = new Map<DynConfigId, DynValidatorFactory<ValidatorFn>>();
-  asyncValidators = new Map<DynConfigId, DynValidatorFactory<AsyncValidatorFn>>();
+  validators = new Map<DynConfigId, DynHandlerFactory<ValidatorFn>>();
+  asyncValidators = new Map<DynConfigId, DynHandlerFactory<AsyncValidatorFn>>();
 
   constructor(
     private readonly logger: DynLogger,
@@ -42,11 +48,11 @@ export class DynFormValidators {
     }
   }
 
-  private dynValidators<V>(
-    dictionary: Map<DynConfigId, DynValidatorFactory<V>>,
+  private dynValidators<F>(
+    dictionary: Map<DynConfigId, DynHandlerFactory<F>>,
     config?: DynConfigCollection,
-  ): V[]|null {
-    let validators: V[] = [];
+  ): F[]|null {
+    let validators: F[] = [];
     if (Array.isArray(config)) {
       // array of ids or [id, args]
       validators = config.map(id => this.getValidatorFn(id, dictionary));
@@ -59,10 +65,10 @@ export class DynFormValidators {
     return validators.length ? validators : null;
   }
 
-  private getValidatorFn<V>(
+  private getValidatorFn<F>(
     config: DynConfigProvider,
-    dictionary: Map<DynConfigId, DynValidatorFactory<V>>,
-  ): V {
+    dictionary: Map<DynConfigId, DynHandlerFactory<F>>,
+  ): F {
     if (Array.isArray(config)) {
       const [id, args] = config;
       if (dictionary.has(id)) {
@@ -80,9 +86,9 @@ export class DynFormValidators {
       : [];
   }
 
-  private reduceProvider<T extends DynBaseValidatorProvider<any>, V>(
+  private reduceProvider<T extends DynBaseHandler<any>, F>(
     providers: T[],
-    dictionary: Map<DynConfigId, DynValidatorFactory<V>>,
+    dictionary: Map<DynConfigId, DynHandlerFactory<F>>,
   ): void {
     // FIXME validate the data-integrity of the provided values and throw logger
     providers

--- a/libs/forms/core/src/form-validators.service.ts
+++ b/libs/forms/core/src/form-validators.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Optional } from '@angular/core';
 import { AbstractControlOptions, AsyncValidatorFn, ValidatorFn } from '@angular/forms';
 import { DynLogger } from '@myndpm/dyn-forms/logger';
-import { DynConfigArgs, DynConfigCollection, DynConfigId, DynControlOptions } from './control-config.types';
+import { DynConfigArgs, DynConfigCollection, DynConfigId, DynConfigProvider, DynControlOptions } from './control-config.types';
 import { DynAsyncValidatorProvider, DynBaseValidatorProvider, DynValidatorFactory, DynValidatorProvider } from './control-validation.types';
 import { defaultValidators } from './dyn-providers';
 import { DYN_ASYNCVALIDATORS_TOKEN, DYN_VALIDATORS_TOKEN } from './form.tokens';
@@ -60,7 +60,7 @@ export class DynFormValidators {
   }
 
   private getValidatorFn<V>(
-    config: DynConfigId | [DynConfigId, DynConfigArgs],
+    config: DynConfigProvider,
     dictionary: Map<DynConfigId, DynValidatorFactory<V>>,
   ): V {
     if (Array.isArray(config)) {

--- a/libs/forms/core/src/form-validators.service.ts
+++ b/libs/forms/core/src/form-validators.service.ts
@@ -60,18 +60,18 @@ export class DynFormValidators {
   }
 
   private getValidatorFn<V>(
-    id: DynConfigId | [DynConfigId, DynConfigArgs],
+    config: DynConfigId | [DynConfigId, DynConfigArgs],
     dictionary: Map<DynConfigId, DynValidatorFactory<V>>,
   ): V {
-    if (Array.isArray(id)) {
-      const [vid, args] = id;
-      if (dictionary.has(vid)) {
-        return (dictionary.get(vid) as DynValidatorFactory<V>)(...this.getArgs(args));
+    if (Array.isArray(config)) {
+      const [id, args] = config;
+      if (dictionary.has(id)) {
+        return dictionary.get(id)!(...this.getArgs(args));
       }
-    } else if (dictionary.has(id)) {
-      return (dictionary.get(id) as DynValidatorFactory<V>)();
+    } else if (dictionary.has(config)) {
+      return dictionary.get(config)!();
     }
-    throw this.logger.validatorNotFound(id);
+    throw this.logger.providerNotFound('Validator', config);
   }
 
   private getArgs(args: DynConfigArgs): DynConfigArgs[] {

--- a/libs/forms/core/src/form-validators.service.ts
+++ b/libs/forms/core/src/form-validators.service.ts
@@ -15,16 +15,18 @@ export class DynFormValidators {
 
   constructor(
     private readonly logger: DynLogger,
-    @Inject(DYN_VALIDATORS_TOKEN) @Optional() readonly vals?: DynValidatorProvider[],
-    @Inject(DYN_ASYNCVALIDATORS_TOKEN) @Optional() readonly avals?: DynAsyncValidatorProvider[],
+    @Inject(DYN_VALIDATORS_TOKEN) @Optional()
+    readonly providedValidators?: DynValidatorProvider[],
+    @Inject(DYN_ASYNCVALIDATORS_TOKEN) @Optional()
+    readonly providedAsyncValidators?: DynAsyncValidatorProvider[],
   ) {
     // reduce the provided validators according to priority
     this.reduceProvider(
-      (this.vals ?? []).concat(defaultValidators), // add Angular's default validators
+      (this.providedValidators ?? []).concat(defaultValidators), // add Angular's default validators
       this.validators,
     );
     this.reduceProvider(
-      (this.avals ?? []),
+      (this.providedAsyncValidators ?? []),
       this.asyncValidators,
     );
   }
@@ -82,7 +84,7 @@ export class DynFormValidators {
     providers: T[],
     dictionary: Map<DynConfigId, DynValidatorFactory<V>>,
   ): void {
-    // FIXME validate the data-integrity of the incoming providers and throw logger
+    // FIXME validate the data-integrity of the provided values and throw logger
     providers
       .reduce(
         // reduce the validators according to the priority

--- a/libs/forms/core/src/form.tokens.ts
+++ b/libs/forms/core/src/form.tokens.ts
@@ -1,5 +1,6 @@
 import { InjectionToken } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
+import { DynControlCondition, DynControlMatcher } from './control-matchers.types';
 import { DynModeControls, DynModeParams, DynControlMode } from './control-mode.types';
 import { ControlProvider } from './control-provider.types';
 import { DynAsyncValidatorProvider, DynValidatorProvider } from './control-validation.types';
@@ -20,6 +21,14 @@ export const DYN_VALIDATORS_TOKEN = new InjectionToken<DynValidatorProvider[]>(
 
 export const DYN_ASYNCVALIDATORS_TOKEN = new InjectionToken<DynAsyncValidatorProvider[]>(
   '@myndpm/dyn-forms/async-validators'
+);
+
+export const DYN_MATCHERS_TOKEN = new InjectionToken<DynControlMatcher[]>(
+  '@myndpm/dyn-forms/matchers'
+);
+
+export const DYN_MATCHER_CONDITIONS_TOKEN = new InjectionToken<DynControlCondition[]>(
+  '@myndpm/dyn-forms/matcher-conditions'
 );
 
 /**

--- a/libs/forms/core/src/module.providers.ts
+++ b/libs/forms/core/src/module.providers.ts
@@ -1,14 +1,18 @@
 import { Provider } from '@angular/core';
 import { DynLogDriver, DynLogger, DynLogLevel, DYN_LOG_LEVEL } from '@myndpm/dyn-forms/logger';
+import { DynControlCondition, DynControlMatcher } from './control-matchers.types';
 import { ControlProvider } from './control-provider.types';
 import { DynAsyncValidatorProvider, DynValidatorProvider } from './control-validation.types';
 import { mapPriority } from './dyn-providers';
 import { DynFormFactory } from './form-factory.service';
+import { DynFormMatchers } from './form-matchers.service';
 import { DynFormRegistry } from './form-registry.service';
 import { DynFormValidators } from './form-validators.service';
 import {
   DYN_ASYNCVALIDATORS_TOKEN,
   DYN_CONTROLS_TOKEN,
+  DYN_MATCHERS_TOKEN,
+  DYN_MATCHER_CONDITIONS_TOKEN,
   DYN_VALIDATORS_TOKEN,
 } from './form.tokens';
 
@@ -17,6 +21,8 @@ export interface DynModuleProviders {
   providers?: Provider[];
   validators?: DynValidatorProvider[];
   asyncValidators?: DynAsyncValidatorProvider[];
+  matchers?: DynControlMatcher[];
+  conditions?: DynControlCondition[];
   priority?: number;
 }
 
@@ -31,6 +37,7 @@ export function getModuleProviders(args?: DynModuleProviders): Provider[] {
     DynLogger,
     DynFormRegistry,
     DynFormValidators,
+    DynFormMatchers,
     DynFormFactory,
     ...args?.providers ?? [],
     ...args?.controls?.map(mapPriority(args?.priority)).map((control) => ({
@@ -46,6 +53,16 @@ export function getModuleProviders(args?: DynModuleProviders): Provider[] {
     ...args?.asyncValidators?.map(mapPriority(args?.priority)).map((asyncValidator) => ({
       provide: DYN_ASYNCVALIDATORS_TOKEN,
       useValue: asyncValidator,
+      multi: true,
+    })) ?? [],
+    ...args?.matchers?.map(mapPriority(args?.priority)).map((matcher) => ({
+      provide: DYN_MATCHERS_TOKEN,
+      useValue: matcher,
+      multi: true,
+    })) ?? [],
+    ...args?.conditions?.map(mapPriority(args?.priority)).map((condition) => ({
+      provide: DYN_MATCHER_CONDITIONS_TOKEN,
+      useValue: condition,
       multi: true,
     })) ?? [],
   ];

--- a/libs/forms/core/src/tree.types.ts
+++ b/libs/forms/core/src/tree.types.ts
@@ -1,4 +1,22 @@
+import { AbstractControl } from '@angular/forms';
+import { DynControlHook } from './control-events.types';
+import { DynInstanceType } from './control.types';
+
 // generic type for hierarchical trees
 export type DynTree<T> = T & {
   children?: T[];
+}
+
+// generic interface of DynFormTreeNode
+export interface DynTreeNode<TControl extends AbstractControl = AbstractControl> {
+  isRoot: boolean;
+  name: string|undefined;
+  path: string[];
+
+  instance: DynInstanceType;
+  control: TControl;
+
+  callHook(event: DynControlHook): void;
+  query(path: string, searchNodes?: boolean): AbstractControl|null;
+  select(path: string): AbstractControl|null;
 }

--- a/libs/forms/lib/components/form/form.component.ts
+++ b/libs/forms/lib/components/form/form.component.ts
@@ -1,4 +1,5 @@
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -31,7 +32,7 @@ import { DynFormConfig } from './form.config';
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [DynFormTreeNode],
 })
-export class DynFormComponent implements OnInit, OnChanges, OnDestroy {
+export class DynFormComponent implements OnInit, AfterViewInit, OnChanges, OnDestroy {
   @Input() isolated = false;
   @Input() form!: FormGroup;
   @Input() config?: DynFormConfig;
@@ -104,6 +105,11 @@ export class DynFormComponent implements OnInit, OnChanges, OnDestroy {
 
     // prevent ExpressionChangedAfterItHasBeenCheckedError
     this.ref.detectChanges();
+  }
+
+  ngAfterViewInit(): void {
+    // trigger processes once the form is built
+    this.node.afterViewInit()
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/libs/forms/lib/components/form/form.config.ts
+++ b/libs/forms/lib/components/form/form.config.ts
@@ -6,7 +6,7 @@ import {
   DynControlMode,
 } from '@myndpm/dyn-forms/core';
 
-// typed config with any supported modes
+// typed config with any set of supported modes
 export interface DynFormConfig<M extends DynControlMode = DynControlMode> {
   controls: Array<DynBaseConfig<M> | DynConfig<M>>;
   modeParams?: DynModeParams<M>; // default params per mode

--- a/libs/forms/logger/src/logger.service.ts
+++ b/libs/forms/logger/src/logger.service.ts
@@ -23,10 +23,10 @@ export class DynLogger {
     });
   }
 
-  validatorNotFound(id: any): Error {
+  providerNotFound(provider: string, config: any): Error {
     return this.driver.log({
       level: DynLogLevel.Fatal,
-      message: `Validator '${id}' not provided.`,
+      message: `${provider} '${JSON.stringify(config)}' not provided.`,
     });
   }
 

--- a/libs/forms/logger/src/logger.service.ts
+++ b/libs/forms/logger/src/logger.service.ts
@@ -26,7 +26,7 @@ export class DynLogger {
   providerNotFound(provider: string, config: any): Error {
     return this.driver.log({
       level: DynLogLevel.Fatal,
-      message: `${provider} '${JSON.stringify(config)}' not provided.`,
+      message: `${provider} ${JSON.stringify(config)} not provided.`,
     });
   }
 


### PR DESCRIPTION
Features applied to the node according to the specified conditions,
like disabling the `address` control if the `country` is not `US`:
```typescript
{
  control: 'INPUT',
  name: 'address',
  matchers: [
    {
      matcher: 'DISABLE',
      when: [
        { path:'country', value: 'US', negate: true }
      ]
    },
  ]
}
```
the matchers options consists of:
```typescript
interface DynControlMatch {
  matcher: DynConfigProvider; // provided at DYN_MATCHERS_TOKEN
  negate?: boolean; // use this matcher in the opposed way (ie. DISABLE -> ENABLE)
  operator?: 'AND' | 'OR';
  when: Array<DynConfigProvider | DynControlMatchCondition>; // provided at DYN_MATCHER_CONDITIONS_TOKEN
}
```
the matcher will receive the AND/OR result of the given conditions.
each condition consists of an `Observable<boolean>` and there's a default handler comparing equality.
It's possible to implement custom condition handler like:
```typescript
when: [{ id: 'STARTSWITH' path: 'name', value: 'Street' }]
```
which will receive this configuration, and should listen the control.valueChanges and return a boolean for the given condition.

Complete documentation TO-BE-DONE