### PR TITLE
feat(ui-material): TABLE DynControl with CSS emulation

### DIFF
--- a/apps/website/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
+++ b/apps/website/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
@@ -133,13 +133,14 @@ export function simpleForm(
           },
         },
       }),
-      createMatConfig('ARRAY', {
+      createMatConfig('TABLE', {
         name: 'products',
         cssClass: 'row',
         params: {
-          title: 'Products',
-          subtitle: 'Items to checkout',
-          initItem: true,
+          title: 'Product',
+          headers: ['Product Name', 'Quality'],
+          // subtitle: 'Items to checkout',
+          // initItem: true,
         },
         controls: [
           createMatConfig('INPUT', {

--- a/apps/website/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
+++ b/apps/website/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
@@ -27,7 +27,7 @@ export const simpleData = {
 
 export function simpleForm(
   obsParams: Observable<DynControlParams>
-): DynFormConfig<'edit'|'display'> { // typed mode
+): DynFormConfig<'edit'|'display'|'row'> { // typed mode
   return {
     modes: {
       edit: { params: { readonly: false } },
@@ -156,6 +156,11 @@ export function simpleForm(
             params: { label: 'Quantity *', type: 'number' },
           }),
         ],
+        modes: {
+          row: {
+            params: { readonly: true },
+          },
+        }
       }),
     ],
     errorMsgs: {

--- a/libs/forms/TODO.md
+++ b/libs/forms/TODO.md
@@ -2,6 +2,7 @@
 
 ## Form Controls
 
+- HIDDEN DynControl not rendering completely is really necessary or enough to setup manually in the FormGroup? it needs special count treatment
 - Check FormDirectives responsibilities to apply in DynFormTreeNode if the validators doesn't work
 - Provide config for appearance (theme, full-width, inline)
 - Extensible handlers for different modes (panel, filter, table-cell, mobile?)
@@ -45,6 +46,10 @@ Fill a DataSource with a Dynamically generated Form.
 
 - Inheritance of DynControls
 - Composition of FormControls
+
+## Troubleshoot
+
+- Buttons without type can trigger `dyn-form` buttons
 
 ## Check the approach of similar projects
 

--- a/libs/forms/core/src/form-config-resolver.service.ts
+++ b/libs/forms/core/src/form-config-resolver.service.ts
@@ -37,7 +37,6 @@ export class DynFormConfigResolver {
     let result: DynBaseConfig = {
       ...config,
       controls: config.controls?.filter(Boolean),
-      modes: undefined,
     };
 
     if (!mode) {

--- a/libs/forms/core/src/form.tokens.ts
+++ b/libs/forms/core/src/form.tokens.ts
@@ -58,7 +58,3 @@ export const DYN_MODE_DEFAULTS = new InjectionToken<DynControlModes>(
 export const DYN_MODE_LOCAL = new InjectionToken<DynControlModes>(
   '@myndpm/dyn-forms/internal/mode-local'
 );
-
-export const DYN_GROUP_NAME = new InjectionToken<BehaviorSubject<string>>(
-  '@myndpm/dyn-forms/internal/group-name'
-);

--- a/libs/forms/logger/src/logger.service.ts
+++ b/libs/forms/logger/src/logger.service.ts
@@ -157,7 +157,7 @@ export class DynLogger {
     });
   }
 
-  modeGroup({ deep, path }: DynNode, name: string, mode: string): void {
+  modeGroup({ deep, path }: DynNode, mode: string, name?: string): void {
     this.driver.log({
       deep,
       level: DynLogLevel.Runtime,

--- a/libs/forms/ui-material/src/components/index.ts
+++ b/libs/forms/ui-material/src/components/index.ts
@@ -18,3 +18,6 @@ export * from './radio/radio.component';
 export * from './radio/radio.component.params';
 export * from './select/select.component';
 export * from './select/select.component.params';
+export * from './table/table.component';
+export * from './table/table.component.params';
+export * from './table-row/table-row.component';

--- a/libs/forms/ui-material/src/components/table-row/table-row.component.html
+++ b/libs/forms/ui-material/src/components/table-row/table-row.component.html
@@ -1,0 +1,33 @@
+<tr class="mat-row">
+  <td class="mat-cell" *ngFor="let control of controls; index as i">
+    <dyn-factory
+      [config]="control"
+      [injector]="configLayer"
+      [index]="i"
+    ></dyn-factory>
+  </td>
+
+  <td class="dyn-table-controls mat-cell">
+    <button
+      *ngIf="mode !== 'edit'"
+      mat-icon-button
+      type="button"
+      (click)="edit.emit()"
+    ><mat-icon>edit</mat-icon></button>
+
+    <button
+      *ngIf="mode !== 'edit'"
+      mat-icon-button
+      type="button"
+      (click)="remove.emit()"
+    ><mat-icon>delete</mat-icon></button>
+
+    <button
+      *ngIf="mode === 'edit'"
+      mat-icon-button
+      type="button"
+      [disabled]="!node.control.valid"
+      (click)="cancel.emit()"
+    ><mat-icon>done</mat-icon></button>
+  </td>
+</tr>

--- a/libs/forms/ui-material/src/components/table-row/table-row.component.html
+++ b/libs/forms/ui-material/src/components/table-row/table-row.component.html
@@ -7,7 +7,7 @@
     ></dyn-factory>
   </td>
 
-  <td class="dyn-table-controls mat-cell">
+  <td class="dyn-table-controls mat-cell" *ngIf="mode !== 'display'">
     <button
       *ngIf="mode !== 'edit'"
       mat-icon-button

--- a/libs/forms/ui-material/src/components/table-row/table-row.component.ts
+++ b/libs/forms/ui-material/src/components/table-row/table-row.component.ts
@@ -2,10 +2,12 @@ import {
   AfterViewInit,
   ChangeDetectionStrategy,
   Component,
+  EventEmitter,
   Injector,
   Input,
   OnInit,
   Optional,
+  Output,
   SkipSelf,
 } from '@angular/core';
 import { FormGroup } from '@angular/forms';
@@ -24,20 +26,19 @@ import {
   recursive,
 } from '@myndpm/dyn-forms/core';
 import { DynLogger } from '@myndpm/dyn-forms/logger';
-import { merge, Observable, Subject } from 'rxjs';
+import { merge, BehaviorSubject, Observable } from 'rxjs';
 import { distinctUntilChanged, map, shareReplay, tap } from 'rxjs/operators';
 
 @Component({
-  selector: 'dyn-group',
-  templateUrl: './group.component.html',
+  selector: 'dyn-mat-table-row',
+  templateUrl: './table-row.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [DynFormTreeNode],
 })
 /**
- * This component just wraps the incoming controls in a FormGroup.
+ * This component just wraps the rows and its mat-cells.
  */
-export class DynGroupComponent extends DynControlNode<any, FormGroup> implements OnInit, AfterViewInit {
-  @Input() isolated = false;
+export class DynMatTableRowComponent extends DynControlNode<any, FormGroup> implements OnInit, AfterViewInit {
   @Input() group!: FormGroup;
   @Input() name?: string;
   @Input() controls?: DynBaseConfig[];
@@ -62,8 +63,12 @@ export class DynGroupComponent extends DynControlNode<any, FormGroup> implements
     return mode;
   }
 
+  @Output() edit = new EventEmitter<void>();
+  @Output() remove = new EventEmitter<void>();
+  @Output() cancel = new EventEmitter<void>();
+
   // stream mode changes via DYN_MODE
-  protected mode$ = new Subject<DynControlMode | undefined>();
+  protected mode$ = new BehaviorSubject<DynControlMode>('');
 
   // internal injector with mode override
   configLayer?: Injector;
@@ -127,15 +132,15 @@ export class DynGroupComponent extends DynControlNode<any, FormGroup> implements
     this.node.load({
       name: this.name,
       controls: this.controls,
-      isolated: Boolean(this.isolated),
+      isolated: false,
     });
     this.node.markParamsAsLoaded();
 
     // log the successful initialization
-    this.logger.nodeLoaded('dyn-group', this.node);
+    this.logger.nodeLoaded('dyn-mat-table-row', this.node);
   }
 
-  ngAfterViewInit() {
+  ngAfterViewInit(): void {
     this.node.markAsLoaded();
   }
 

--- a/libs/forms/ui-material/src/components/table/table.component.html
+++ b/libs/forms/ui-material/src/components/table/table.component.html
@@ -1,0 +1,37 @@
+<div *ngIf="!items?.length" class="alert alert-light" role="alert">
+  {{ params.emptyText }}
+
+  <button mat-button color="accent" (click)="addItem(true)">
+    {{ params.addNewButtonText }}
+  </button>
+</div>
+
+<ng-container *ngIf="node.mode$ | async as mode">
+
+  <table class="mat-table mat-elevation-z2" *ngIf="items?.length">
+    <tr class="mat-header-row">
+      <th *ngFor="let header of params.headers" class="mat-header-cell">
+        {{ header }}
+      </th>
+      <th *ngIf="mode === 'edit'" class="mat-header-cell">
+        <button mat-button color="accent" (click)="addItem(true)">
+          {{ params.addNewButtonText }}
+        </button>
+      </th>
+    </tr>
+
+    <dyn-mat-table-row
+      *ngFor="let item of items; let i = index"
+      [controls]="config.controls"
+      [modes]="config.modes"
+      [group]="item"
+      [name]="i.toString()"
+      [mode]="itemIndexForEditing == i ? 'edit' : 'display'"
+      [modeFactory]="modeFactory"
+      (edit)="editItem(i)"
+      (remove)="removeItem(i)"
+      (cancel)="cancelItemEditing()"
+    ></dyn-mat-table-row>
+  </table>
+
+</ng-container>

--- a/libs/forms/ui-material/src/components/table/table.component.html
+++ b/libs/forms/ui-material/src/components/table/table.component.html
@@ -26,7 +26,7 @@
       [modes]="config.modes"
       [group]="item"
       [name]="i.toString()"
-      [mode]="itemIndexForEditing == i ? 'edit' : 'display'"
+      [mode]="modeFactory(mode, i.toString())"
       [modeFactory]="modeFactory"
       (edit)="editItem(i)"
       (remove)="removeItem(i)"

--- a/libs/forms/ui-material/src/components/table/table.component.params.ts
+++ b/libs/forms/ui-material/src/components/table/table.component.params.ts
@@ -1,0 +1,8 @@
+import { DynControlParams } from '@myndpm/dyn-forms/core';
+
+export interface DynMatTableParams extends DynControlParams {
+  title: string;
+  addNewButtonText: string;
+  emptyText?: string;
+  headers: string[];
+}

--- a/libs/forms/ui-material/src/components/table/table.component.scss
+++ b/libs/forms/ui-material/src/components/table/table.component.scss
@@ -68,4 +68,20 @@ $row-horizontal-padding: 24px;
     word-wrap: break-word;
     min-height: inherit;
   }
+
+  // FIXME temporary style customizations to INPUT only
+  .mat-cell {
+    .mat-form-field-infix {
+      border-top: 0;
+    }
+    .mat-form-field-wrapper {
+      padding-bottom: 0;
+    }
+    .mat-form-field-label-wrapper {
+      display: none !important;
+    }
+    input.mat-input-element {
+      margin-top: 0 !important;
+    }
+  }
 }

--- a/libs/forms/ui-material/src/components/table/table.component.scss
+++ b/libs/forms/ui-material/src/components/table/table.component.scss
@@ -1,0 +1,71 @@
+// @angular/material/table/_table-flex-styles.scss
+
+// flex-based table structure
+$header-row-height: 56px;
+$row-height: 48px;
+$row-horizontal-padding: 24px;
+
+::ng-deep {
+  .mat-table {
+    display: block;
+  }
+
+  .mat-header-row {
+    min-height: $header-row-height;
+  }
+
+  .mat-row, .mat-footer-row {
+    min-height: $row-height;
+  }
+
+  .mat-row, .mat-header-row, .mat-footer-row {
+    display: flex;
+    // Define a border style, but then widths default to 3px. Reset them to 0px except the bottom
+    // which should be 1px;
+    border-width: 0;
+    border-bottom-width: 1px;
+    border-style: solid;
+    align-items: center;
+    box-sizing: border-box;
+
+    // Workaround for https://goo.gl/pFmjJD in IE 11. Adds a pseudo
+    // element that will stretch the row the correct height. See:
+    // https://connect.microsoft.com/IE/feedback/details/802625
+    &::after {
+      display: inline-block;
+      min-height: inherit;
+      content: '';
+    }
+  }
+
+  .mat-cell, .mat-header-cell, .mat-footer-cell {
+    // Note: we use `first-of-type`/`last-of-type` here in order to prevent extra
+    // elements like ripples or badges from throwing off the layout (see #11165).
+    &:first-of-type {
+      padding-left: $row-horizontal-padding;
+
+      [dir='rtl'] &:not(:only-of-type) {
+        padding-left: 0;
+        padding-right: $row-horizontal-padding;
+      }
+    }
+
+    &:last-of-type {
+      padding-right: $row-horizontal-padding;
+
+      [dir='rtl'] &:not(:only-of-type) {
+        padding-right: 0;
+        padding-left: $row-horizontal-padding;
+      }
+    }
+  }
+
+  .mat-cell, .mat-header-cell, .mat-footer-cell {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    overflow: hidden;
+    word-wrap: break-word;
+    min-height: inherit;
+  }
+}

--- a/libs/forms/ui-material/src/components/table/table.component.ts
+++ b/libs/forms/ui-material/src/components/table/table.component.ts
@@ -78,6 +78,8 @@ implements OnInit {
   }
 
   modeFactory = (mode: DynControlMode, index?: string): DynControlMode => {
-    return this.itemIndexForEditing === Number(index) ? 'edit' : 'display';
+    return mode !== 'display'
+      ? this.itemIndexForEditing === Number(index) ? 'edit' : 'row'
+      : mode;
   }
 }

--- a/libs/forms/ui-material/src/components/table/table.component.ts
+++ b/libs/forms/ui-material/src/components/table/table.component.ts
@@ -1,0 +1,83 @@
+import { ChangeDetectionStrategy, Component, Injector, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { DynConfig, DynControlMode, DynFormArray, DynPartialControlConfig } from '@myndpm/dyn-forms/core';
+import { filter, takeUntil } from 'rxjs/operators';
+
+import { DynMatTableParams } from './table.component.params';
+
+@Component({
+  selector: 'dyn-mat-table',
+  templateUrl: './table.component.html',
+  styleUrls: ['./table.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DynMatTableComponent
+extends DynFormArray<DynControlMode, DynMatTableParams>
+implements OnInit {
+
+  static dynControl: 'TABLE' = 'TABLE';
+
+  static createConfig<M extends DynControlMode>(
+    partial: DynPartialControlConfig<M, DynMatTableParams>
+  ): DynConfig<M, DynMatTableParams> {
+    return {
+      ...partial,
+      control: DynMatTableComponent.dynControl,
+    };
+  }
+
+  get items(): FormGroup[] {
+    return this.control.controls as FormGroup[];
+  }
+
+  itemIndexForEditing?: number;
+
+  constructor(
+    injector: Injector,
+  ) {
+    super(injector);
+  }
+
+  ngOnInit(): void {
+    super.ngOnInit();
+
+    this.node.mode$
+      .pipe(
+        filter(mode => mode === 'display'),
+        takeUntil(this.onDestroy$),
+      )
+      .subscribe(() => this.itemIndexForEditing = undefined);
+  }
+
+  addItem(userAction?: boolean): void {
+    super.addItem();
+    if (userAction) {
+      this.itemIndexForEditing = this.items.length - 1;
+    }
+  }
+
+  cancelItemEditing(): void {
+    this.itemIndexForEditing = undefined;
+  }
+
+  editItem(index: number): void {
+    this.itemIndexForEditing = index;
+  }
+
+  removeItem(index: number): void {
+    super.removeItem(index);
+  }
+
+  completeParams(params: Partial<DynMatTableParams>): DynMatTableParams {
+    return {
+      title: params.title!,
+      addNewButtonText: params.addNewButtonText || `Add ${ params.title!.toLowerCase() }`,
+      emptyText: params.emptyText || `No ${ params.title!.toLowerCase() }s added`,
+      headers: params.headers || [],
+    };
+  }
+
+  modeFactory = (mode: DynControlMode, index?: string): DynControlMode => {
+    return this.itemIndexForEditing === Number(index) ? 'edit' : 'display';
+  }
+}

--- a/libs/forms/ui-material/src/dyn-forms-material.factory.ts
+++ b/libs/forms/ui-material/src/dyn-forms-material.factory.ts
@@ -27,6 +27,8 @@ import {
   DynMatRadioParams,
   DynMatSelectComponent,
   DynMatSelectParams,
+  DynMatTableComponent,
+  DynMatTableParams,
 } from './components';
 
 // type overloads
@@ -70,6 +72,10 @@ export function createMatConfig<M extends DynControlMode>(
   type: typeof DynMatSelectComponent.dynControl,
   partial: DynPartialControlConfig<M, Partial<DynMatSelectParams>>
 ): DynConfig<M>;
+export function createMatConfig<M extends DynControlMode>(
+  type: typeof DynMatTableComponent.dynControl,
+  partial: DynPartialControlConfig<M, Partial<DynMatTableParams>>
+): DynConfig<M>;
 
 // factory
 export function createMatConfig<M extends DynControlMode>(
@@ -100,11 +106,14 @@ export function createMatConfig<M extends DynControlMode>(
     case DynMatMulticheckboxComponent.dynControl:
       return DynMatMulticheckboxComponent.createConfig(partial);
 
+    case DynMatRadioComponent.dynControl:
+      return DynMatRadioComponent.createConfig(partial);
+
     case DynMatSelectComponent.dynControl:
       return DynMatSelectComponent.createConfig(partial);
 
-    case DynMatRadioComponent.dynControl:
-      return DynMatRadioComponent.createConfig(partial);
+    case DynMatTableComponent.dynControl:
+      return DynMatTableComponent.createConfig(partial);
 
     case DynMatInputComponent.dynControl:
     default:

--- a/libs/forms/ui-material/src/dyn-forms-material.module.ts
+++ b/libs/forms/ui-material/src/dyn-forms-material.module.ts
@@ -25,6 +25,8 @@ import {
   DynMatMulticheckboxComponent,
   DynMatRadioComponent,
   DynMatSelectComponent,
+  DynMatTableComponent,
+  DynMatTableRowComponent,
 } from './components';
 
 export const PROVIDERS = getModuleProviders({
@@ -82,6 +84,11 @@ export const PROVIDERS = getModuleProviders({
       instance: DynMatSelectComponent.dynInstance,
       component: DynMatSelectComponent,
     },
+    {
+      control: DynMatTableComponent.dynControl,
+      instance: DynMatTableComponent.dynInstance,
+      component: DynMatTableComponent,
+    },
   ],
 });
 
@@ -113,6 +120,8 @@ export const PROVIDERS = getModuleProviders({
     DynMatMulticheckboxComponent,
     DynMatRadioComponent,
     DynMatSelectComponent,
+    DynMatTableComponent,
+    DynMatTableRowComponent,
   ],
   // FIXME added for Stackblitz
   entryComponents: [
@@ -126,6 +135,8 @@ export const PROVIDERS = getModuleProviders({
     DynMatMulticheckboxComponent,
     DynMatRadioComponent,
     DynMatSelectComponent,
+    DynMatTableComponent,
+    DynMatTableRowComponent,
   ],
   exports: [
     // reduce the boilerplate


### PR DESCRIPTION
Here is the real life case of a table with internal modes different than the main one.

The material TABLE only shows the edit/delete controls on `edit` mode,
and internally it uses `row` and `edit` mode for each item in the Form Array.

The usability decisions are quite customized with these modes for the intended usage.

PS. this PR improvised the displaying of cells with some CSS overrides to the input control only,
but the definitive solution is a new DynControl to just display cell information.