### PR TITLE
dyn-forms: TABLE hooks and core Matchers and Condition

### DIFF
--- a/apps/website/src/app/demos/submodules/dyn-forms/components/simple/simple.component.html
+++ b/apps/website/src/app/demos/submodules/dyn-forms/components/simple/simple.component.html
@@ -17,6 +17,10 @@
           Submit
         </button>
 
+        <button type="button" mat-raised-button color="accent" *ngIf="mode === 'edit'" (click)="addProduct()">
+          Add Product
+        </button>
+
         <button type="button" mat-raised-button color="accent" *ngIf="mode === 'edit'" (click)="onCancel()">
           Cancel
         </button>

--- a/apps/website/src/app/demos/submodules/dyn-forms/components/simple/simple.component.ts
+++ b/apps/website/src/app/demos/submodules/dyn-forms/components/simple/simple.component.ts
@@ -8,8 +8,8 @@ import {
 } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { DynFormComponent } from '@myndpm/dyn-forms';
-import { BehaviorSubject } from 'rxjs';
-import { distinctUntilChanged, startWith } from 'rxjs/operators';
+import { BehaviorSubject, Subject } from 'rxjs';
+import { distinctUntilChanged, startWith, takeUntil } from 'rxjs/operators';
 import { actions, badges } from '../../constants/dyn-forms.links';
 import { simpleData, simpleForm } from './simple.form';
 
@@ -32,14 +32,19 @@ export class SimpleComponent implements AfterViewInit, OnDestroy {
     ...actions,
   ];
 
-  // reactive parameters for the billing CARD
-  profileCard = new BehaviorSubject({
+  // reactive parameters for the form config
+  profileCard$ = new BehaviorSubject({
     title: 'Billing Address',
     subtitle: 'Please fill the required fields',
   });
+  addItem$ = new Subject<{ userAction?: boolean }>();
+  itemAdded$ = new Subject<any>();
+  itemEdited$ = new Subject<any>();
+  itemDeleted$ = new Subject<any>();
+  onDestroy$ = new Subject<void>();
 
   // dyn-form inputs
-  config = simpleForm(this.profileCard);
+  config = simpleForm(this.profileCard$, this.addItem$, this.itemAdded$, this.itemEdited$, this.itemDeleted$);
   form = new FormGroup({});
   mode = 'edit';
 
@@ -55,7 +60,7 @@ export class SimpleComponent implements AfterViewInit, OnDestroy {
     group.statusChanges
       .pipe(startWith(group.status), distinctUntilChanged())
       .subscribe((status) => {
-        this.profileCard.next({
+        this.profileCard$.next({
           title: 'Billing Address',
           subtitle: status === 'INVALID'
             ? 'Please fill your Personal Information'
@@ -63,12 +68,25 @@ export class SimpleComponent implements AfterViewInit, OnDestroy {
         });
       });
 
+    // listen event observers
+    this.itemAdded$
+      .pipe(takeUntil(this.onDestroy$))
+      .subscribe((payload) => console.log('Item Added:', payload))
+    this.itemEdited$
+      .pipe(takeUntil(this.onDestroy$))
+      .subscribe((payload) => console.log('Item Edited:', payload))
+    this.itemDeleted$
+      .pipe(takeUntil(this.onDestroy$))
+      .subscribe((payload) => console.log('Item Deleted:', payload))
+
     // initial state of the form is `edit` mode
     this.dynForm.track('display');
   }
 
   ngOnDestroy(): void {
     console.clear();
+    this.onDestroy$.next();
+    this.onDestroy$.complete();
   }
 
   loadData(): void {
@@ -82,6 +100,10 @@ export class SimpleComponent implements AfterViewInit, OnDestroy {
     // reset previous interactions
     this.form.markAsPristine();
     this.form.markAsUntouched();
+  }
+
+  addProduct(): void {
+    this.addItem$.next({ userAction: true });
   }
 
   onSubmit(): void {

--- a/apps/website/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
+++ b/apps/website/src/app/demos/submodules/dyn-forms/components/simple/simple.form.ts
@@ -1,7 +1,7 @@
 import { DynFormConfig } from '@myndpm/dyn-forms';
 import { DynParams } from '@myndpm/dyn-forms/core';
 import { createMatConfig } from '@myndpm/dyn-forms/ui-material';
-import { Observable } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 
 export const simpleData = {
   billing: {
@@ -26,7 +26,11 @@ export const simpleData = {
 };
 
 export function simpleForm(
-  obsParams: Observable<DynParams>
+  obsParams$: Observable<DynParams>,
+  addItem$: Observable<{ userAction?: boolean }>,
+  itemAdded$: Subject<any>,
+  itemEdited$: Subject<any>,
+  itemDeleted$: Subject<any>,
 ): DynFormConfig<'edit'|'display'|'row'> { // typed mode
   return {
     modes: {
@@ -37,7 +41,7 @@ export function simpleForm(
       createMatConfig('CARD', {
         name: 'billing',
         cssClass: 'row',
-        params: obsParams,
+        params: obsParams$,
         controls: [
           createMatConfig('INPUT', {
             name: 'firstName',
@@ -148,6 +152,24 @@ export function simpleForm(
                 validators: ['required', ['min', 1]],
                 params: { label: 'Quantity', type: 'number' },
               }),
+            ],
+            match: [
+              {
+                matchers: [['CALL_HOOK', 'AddItem']],
+                when: [() => addItem$],
+              },
+              {
+                matchers: [['LISTEN_HOOK', itemAdded$]],
+                when: [['HOOK', 'ItemAdded']]
+              },
+              {
+                matchers: [['LISTEN_HOOK', itemEdited$]],
+                when: [['HOOK', 'ItemEdited']]
+              },
+              {
+                matchers: [['LISTEN_HOOK', itemDeleted$]],
+                when: [['HOOK', 'ItemDeleted']]
+              },
             ],
             modes: {
               row: {

--- a/libs/forms/core/src/types/node.types.ts
+++ b/libs/forms/core/src/types/node.types.ts
@@ -26,6 +26,7 @@ export interface DynNode<
   ready$: Observable<boolean>;
   mode$: Observable<string>;
   params$: Observable<TParams>;
+  hook$: Observable<DynHook>;
 
   visible(): void;
   invisible(): void;

--- a/libs/forms/ui-material/src/controls/table/table.component.html
+++ b/libs/forms/ui-material/src/controls/table/table.component.html
@@ -34,7 +34,7 @@
       (edit)="editItem(i)"
       (remove)="removeItem(i)"
       (cancel)="cancelItem(i)"
-      (save)="cancelItem()"
+      (save)="saveItem(i)"
     ></tr>
   </table>
 

--- a/libs/forms/ui-material/src/controls/table/table.component.params.ts
+++ b/libs/forms/ui-material/src/controls/table/table.component.params.ts
@@ -6,3 +6,11 @@ export interface DynMatTableParams extends DynParams {
   emptyText?: string;
   headers: string[];
 }
+
+/**
+ * Hooks
+ */
+
+export interface DynMatTableAddItemHook {
+  userAction?: boolean;
+}


### PR DESCRIPTION
A new example on the `TABLE` control was implemented: triggering and listening Hooks:
```
match: [
  {
    matchers: [['CALL_HOOK', 'AddItem']],
    when: [() => addItem$],
  },
  {
    matchers: [['LISTEN_HOOK', itemAdded$]],
    when: [['HOOK', 'ItemAdded']]
  },
  {
    matchers: [['LISTEN_HOOK', itemEdited$]],
    when: [['HOOK', 'ItemEdited']]
  },
  {
    matchers: [['LISTEN_HOOK', itemDeleted$]],
    when: [['HOOK', 'ItemDeleted']]
  },
],
```
the simple-demo component is able to trigger the `AddItem` hook with `addItem$`
and listen the hooks of this DynControl via the `itemAdded$`, `itemEdited$` and `itemDeleted$` observers.